### PR TITLE
feat: add Windows skill installer and buildable library output

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Long-term facts, daily logs, and a scratchpad checklist stored as plain markdown
 
 ```bash
 # Install the CLI globally
-npm install -g agent-memory
+npm install -g myagentmemory
 
 # Or build from source
 bun run build:cli

--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ agent-memory init
 
 # Install skill files for Claude Code and Codex
 bash scripts/install-skills.sh
+pwsh -File scripts/install-skills.ps1
 ```
 
 This installs:
 - `~/.claude/skills/agent-memory/SKILL.md` — Claude Code skill
 - `~/.codex/skills/agent-memory/SKILL.md` — Codex skill
+- `%USERPROFILE%\.claude\skills\agent-memory\SKILL.md` — Claude Code skill (Windows)
+- `%USERPROFILE%\.codex\skills\agent-memory\SKILL.md` — Codex skill (Windows)
 
 ### Optional: Enable search with qmd
 
@@ -175,6 +178,7 @@ agent-memory write --target long_term --content "test" && agent-memory read --ta
 
 # Install skills
 bash scripts/install-skills.sh
+pwsh -File scripts/install-skills.ps1
 ```
 
 ## Publishing (maintainers)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memory",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memory",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memory",
-  "version": "0.3.5",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memory",
-      "version": "0.3.5",
+      "version": "0.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-memory",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-memory",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-memory",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Persistent memory for coding agents (Claude Code, Codex) with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "./dist/core.js",
 	"types": "./dist/core.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "myagentmemory",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"description": "Persistent memory for coding agents (Claude Code, Codex) with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "./dist/core.js",
 	"types": "./dist/core.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "agent-memory",
+	"name": "myagentmemory",
 	"version": "0.4.2",
 	"description": "Persistent memory for coding agents (Claude Code, Codex) with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "./dist/core.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,14 @@
 	"name": "agent-memory",
 	"version": "0.4.0",
 	"description": "Persistent memory for coding agents (Claude Code, Codex) with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
-	"main": "src/core.ts",
+	"main": "./dist/core.js",
+	"types": "./dist/core.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/core.d.ts",
+			"default": "./dist/core.js"
+		}
+	},
 	"bin": {
 		"agent-memory": "./dist/agent-memory"
 	},
@@ -42,7 +49,9 @@
 	"scripts": {
 		"postinstall": "node scripts/postinstall.cjs",
 		"build": "tsc -p tsconfig.json --noEmit",
+		"build:lib": "tsc -p tsconfig.build.json",
 		"build:cli": "bun build src/cli.ts --compile --outfile dist/agent-memory",
+		"prepack": "npm run build:lib && bun run build:cli",
 		"lint": "biome check .",
 		"test": "bun test test/unit.test.ts",
 		"test:unit": "bun test test/unit.test.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agent-memory",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Persistent memory for coding agents (Claude Code, Codex) with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "./dist/core.js",
 	"types": "./dist/core.d.ts",

--- a/scripts/install-skills.ps1
+++ b/scripts/install-skills.ps1
@@ -1,0 +1,48 @@
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectDir = Split-Path -Parent $ScriptDir
+
+# Claude Code skill
+$ClaudeSkillDir = Join-Path $env:USERPROFILE ".claude\\skills\\agent-memory"
+$ClaudeSkillSrc = Join-Path $ProjectDir "skills\\claude-code\\SKILL.md"
+if (Test-Path $ClaudeSkillSrc) {
+	New-Item -ItemType Directory -Force -Path $ClaudeSkillDir | Out-Null
+	Copy-Item -Force $ClaudeSkillSrc (Join-Path $ClaudeSkillDir "SKILL.md")
+	Write-Host "Installed Claude Code skill: $ClaudeSkillDir\\SKILL.md"
+} else {
+	Write-Host "Skipping Claude Code skill (skills\\claude-code\\SKILL.md not found)"
+}
+
+# Codex skill
+$CodexSkillDir = Join-Path $env:USERPROFILE ".codex\\skills\\agent-memory"
+$CodexSkillSrc = Join-Path $ProjectDir "skills\\codex\\SKILL.md"
+if (Test-Path $CodexSkillSrc) {
+	New-Item -ItemType Directory -Force -Path $CodexSkillDir | Out-Null
+	Copy-Item -Force $CodexSkillSrc (Join-Path $CodexSkillDir "SKILL.md")
+	Write-Host "Installed Codex skill: $CodexSkillDir\\SKILL.md"
+} else {
+	Write-Host "Skipping Codex skill (skills\\codex\\SKILL.md not found)"
+}
+
+Write-Host ""
+Write-Host "Done."
+Write-Host ""
+
+$BinExe = Join-Path $ProjectDir "dist\\agent-memory.exe"
+$Bin = Join-Path $ProjectDir "dist\\agent-memory"
+if (Test-Path $BinExe) {
+	Write-Host "Add this directory to your PATH:"
+	Write-Host "  $(Join-Path $ProjectDir 'dist')"
+} elseif (Test-Path $Bin) {
+	Write-Host "Add this directory to your PATH:"
+	Write-Host "  $(Join-Path $ProjectDir 'dist')"
+} else {
+	Write-Host "Build the CLI binary first:"
+	Write-Host "  bun run build:cli"
+	Write-Host "Then add this directory to your PATH:"
+	Write-Host "  $(Join-Path $ProjectDir 'dist')"
+}
+
+Write-Host ""
+Write-Host "Initialize memory: agent-memory init"

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -28,7 +28,28 @@ else
 fi
 
 echo ""
-echo "Done. Make sure 'agent-memory' is on your PATH:"
-echo "  npm install -g agent-memory   # or: bun run build:cli && ln -s dist/agent-memory /usr/local/bin/"
+echo "Done."
+echo ""
+AGENT_MEMORY_BIN="$PROJECT_DIR/dist/agent-memory"
+if [ -x "$AGENT_MEMORY_BIN" ]; then
+  if [ -d "$HOME/.local/bin" ]; then
+    if ln -sf "$AGENT_MEMORY_BIN" "$HOME/.local/bin/agent-memory" 2>/dev/null; then
+      echo "Linked agent-memory into: $HOME/.local/bin/agent-memory"
+      echo "Ensure $HOME/.local/bin is on your PATH."
+    else
+      echo "Could not link to $HOME/.local/bin (permissions)."
+      echo "Add this to your PATH instead:"
+      echo "  $AGENT_MEMORY_BIN"
+    fi
+  else
+    echo "Make sure 'agent-memory' is on your PATH:"
+    echo "  $AGENT_MEMORY_BIN"
+  fi
+else
+  echo "Build the CLI binary first:"
+  echo "  bun run build:cli"
+  echo "Then add it to your PATH:"
+  echo "  $AGENT_MEMORY_BIN"
+fi
 echo ""
 echo "Initialize memory: agent-memory init"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -238,12 +238,7 @@ async function cmdRead(flags: Record<string, string | boolean>) {
 	if (target === "scratchpad") {
 		const content = readFileSafe(getScratchpadFile());
 		if (!content?.trim()) {
-			output(
-				json
-					? { content: null }
-					: "SCRATCHPAD.md is empty or does not exist.",
-				json,
-			);
+			output(json ? { content: null } : "SCRATCHPAD.md is empty or does not exist.", json);
 			return;
 		}
 		output(json ? { content, path: getScratchpadFile() } : content, json);
@@ -253,28 +248,19 @@ async function cmdRead(flags: Record<string, string | boolean>) {
 	// long_term
 	const content = readFileSafe(getMemoryFile());
 	if (!content) {
-		output(
-			json ? { content: null } : "MEMORY.md is empty or does not exist.",
-			json,
-		);
+		output(json ? { content: null } : "MEMORY.md is empty or does not exist.", json);
 		return;
 	}
 	output(json ? { content, path: getMemoryFile() } : content, json);
 }
 
-async function cmdScratchpad(
-	flags: Record<string, string | boolean>,
-	positional: string[],
-) {
+async function cmdScratchpad(flags: Record<string, string | boolean>, positional: string[]) {
 	const json = hasFlag(flags, "json");
 	const action = positional[0];
 	const text = getFlag(flags, "text");
 
 	if (!action || !["add", "done", "undo", "clear_done", "list"].includes(action)) {
-		exitError(
-			"Usage: agent-memory scratchpad <add|done|undo|clear_done|list> [--text <text>]",
-			json,
-		);
+		exitError("Usage: agent-memory scratchpad <add|done|undo|clear_done|list> [--text <text>]", json);
 	}
 
 	ensureDirs();
@@ -288,11 +274,14 @@ async function cmdScratchpad(
 			return;
 		}
 		if (json) {
-			output({
-				items: items.map((i) => ({ done: i.done, text: i.text })),
-				count: items.length,
-				open: items.filter((i) => !i.done).length,
-			}, true);
+			output(
+				{
+					items: items.map((i) => ({ done: i.done, text: i.text })),
+					count: items.length,
+					open: items.filter((i) => !i.done).length,
+				},
+				true,
+			);
 		} else {
 			console.log(serializeScratchpad(items));
 		}
@@ -323,10 +312,7 @@ async function cmdScratchpad(
 			}
 		}
 		if (!matched) {
-			exitError(
-				`No matching ${targetDone ? "open" : "done"} item found for: "${text}"`,
-				json,
-			);
+			exitError(`No matching ${targetDone ? "open" : "done"} item found for: "${text}"`, json);
 		}
 		fs.writeFileSync(spFile, serializeScratchpad(items), "utf-8");
 		await ensureQmdAvailableForUpdate();
@@ -342,10 +328,7 @@ async function cmdScratchpad(
 		fs.writeFileSync(spFile, serializeScratchpad(items), "utf-8");
 		await ensureQmdAvailableForUpdate();
 		scheduleQmdUpdate();
-		output(
-			json ? { ok: true, action, removed } : `Cleared ${removed} done item(s).`,
-			json,
-		);
+		output(json ? { ok: true, action, removed } : `Cleared ${removed} done item(s).`, json);
 	}
 }
 
@@ -368,10 +351,7 @@ async function cmdSearch(flags: Record<string, string | boolean>) {
 	const collName = getCollectionName();
 	const hasCollection = await checkCollection(collName);
 	if (!hasCollection) {
-		exitError(
-			`qmd collection '${collName}' not found. Run: agent-memory init`,
-			json,
-		);
+		exitError(`qmd collection '${collName}' not found. Run: agent-memory init`, json);
 	}
 
 	try {
@@ -385,9 +365,7 @@ async function cmdSearch(flags: Record<string, string | boolean>) {
 		if (results.length === 0) {
 			const needsEmbed = /need embeddings/i.test(stderr ?? "");
 			if (needsEmbed && (mode === "semantic" || mode === "deep")) {
-				console.log(
-					`No results found. qmd reports missing embeddings — run: qmd embed`,
-				);
+				console.log(`No results found. qmd reports missing embeddings — run: qmd embed`);
 			} else {
 				console.log(`No results found for "${query}" (mode: ${mode}).`);
 			}
@@ -405,10 +383,7 @@ async function cmdSearch(flags: Record<string, string | boolean>) {
 			console.log("");
 		}
 	} catch (err) {
-		exitError(
-			`Search failed: ${err instanceof Error ? err.message : String(err)}`,
-			json,
-		);
+		exitError(`Search failed: ${err instanceof Error ? err.message : String(err)}`, json);
 	}
 }
 
@@ -430,12 +405,15 @@ async function cmdInit(flags: Record<string, string | boolean>) {
 	}
 
 	if (json) {
-		output({
-			ok: true,
-			directory: dir,
-			qmd: qmdFound,
-			collectionCreated,
-		}, true);
+		output(
+			{
+				ok: true,
+				directory: dir,
+				qmd: qmdFound,
+				collectionCreated,
+			},
+			true,
+		);
 	} else {
 		console.log(`Memory directory: ${dir}`);
 		console.log(`  MEMORY.md, SCRATCHPAD.md, daily/ created.`);
@@ -466,9 +444,7 @@ async function cmdStatus(flags: Record<string, string | boolean>) {
 
 	let dailyCount = 0;
 	try {
-		dailyCount = fs
-			.readdirSync(dailyDir)
-			.filter((f) => f.endsWith(".md")).length;
+		dailyCount = fs.readdirSync(dailyDir).filter((f) => f.endsWith(".md")).length;
 	} catch {
 		// directory may not exist
 	}
@@ -480,26 +456,27 @@ async function cmdStatus(flags: Record<string, string | boolean>) {
 	}
 
 	if (json) {
-		output({
-			directory: dir,
-			memoryFile: {
-				exists: memContent !== null,
-				chars: memContent?.length ?? 0,
-				lines: memContent ? memContent.split("\n").length : 0,
+		output(
+			{
+				directory: dir,
+				memoryFile: {
+					exists: memContent !== null,
+					chars: memContent?.length ?? 0,
+					lines: memContent ? memContent.split("\n").length : 0,
+				},
+				scratchpadFile: {
+					exists: spContent !== null,
+					items: spContent ? parseScratchpad(spContent).length : 0,
+					openItems: spContent ? parseScratchpad(spContent).filter((i) => !i.done).length : 0,
+				},
+				dailyLogs: dailyCount,
+				qmd: {
+					available: qmdFound,
+					collection: hasCollection ? getCollectionName() : null,
+				},
 			},
-			scratchpadFile: {
-				exists: spContent !== null,
-				items: spContent ? parseScratchpad(spContent).length : 0,
-				openItems: spContent
-					? parseScratchpad(spContent).filter((i) => !i.done).length
-					: 0,
-			},
-			dailyLogs: dailyCount,
-			qmd: {
-				available: qmdFound,
-				collection: hasCollection ? getCollectionName() : null,
-			},
-		}, true);
+			true,
+		);
 	} else {
 		console.log(`Memory directory: ${dir}`);
 		console.log("");

--- a/src/core.ts
+++ b/src/core.ts
@@ -13,8 +13,7 @@ import * as path from "node:path";
 // Paths (mutable for testing via _setBaseDir / _resetBaseDir)
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MEMORY_DIR =
-	process.env.AGENT_MEMORY_DIR ?? path.join(process.env.HOME ?? "~", ".agent-memory");
+const DEFAULT_MEMORY_DIR = process.env.AGENT_MEMORY_DIR ?? path.join(process.env.HOME ?? "~", ".agent-memory");
 
 let MEMORY_DIR = DEFAULT_MEMORY_DIR;
 let MEMORY_FILE = path.join(MEMORY_DIR, "MEMORY.md");
@@ -683,9 +682,7 @@ export function runQmdSearch(
 			}
 			try {
 				const parsed = parseQmdJson(stdout);
-				const results = Array.isArray(parsed)
-					? parsed
-					: ((parsed as any).results ?? (parsed as any).hits ?? []);
+				const results = Array.isArray(parsed) ? parsed : ((parsed as any).results ?? (parsed as any).hits ?? []);
 				resolve({ results, stderr: stderr ?? "" });
 			} catch (parseErr) {
 				if (parseErr instanceof Error) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -132,7 +132,7 @@ describe("write operations", () => {
 
 		const existing = readFileSafe(filePath) ?? "";
 		const separator = existing.trim() ? "\n\n" : "";
-		fs.writeFileSync(filePath, existing + separator + "Afternoon entry", "utf-8");
+		fs.writeFileSync(filePath, `${existing + separator}Afternoon entry`, "utf-8");
 
 		const result = readFileSafe(filePath)!;
 		expect(result).toContain("Morning entry");
@@ -334,8 +334,17 @@ describe("CLI subprocess", () => {
 		// Write
 		const writeResult = Bun.spawnSync(
 			[
-				"bun", "run", path.join(__dirname, "..", "src", "cli.ts"),
-				"write", "--dir", tmpDir, "--target", "long_term", "--content", "Test content", "--json",
+				"bun",
+				"run",
+				path.join(__dirname, "..", "src", "cli.ts"),
+				"write",
+				"--dir",
+				tmpDir,
+				"--target",
+				"long_term",
+				"--content",
+				"Test content",
+				"--json",
 			],
 			{ stdout: "pipe", stderr: "pipe" },
 		);
@@ -346,8 +355,15 @@ describe("CLI subprocess", () => {
 		// Read
 		const readResult = Bun.spawnSync(
 			[
-				"bun", "run", path.join(__dirname, "..", "src", "cli.ts"),
-				"read", "--dir", tmpDir, "--target", "long_term", "--json",
+				"bun",
+				"run",
+				path.join(__dirname, "..", "src", "cli.ts"),
+				"read",
+				"--dir",
+				tmpDir,
+				"--target",
+				"long_term",
+				"--json",
 			],
 			{ stdout: "pipe", stderr: "pipe" },
 		);
@@ -362,8 +378,14 @@ describe("CLI subprocess", () => {
 
 		const result = Bun.spawnSync(
 			[
-				"bun", "run", path.join(__dirname, "..", "src", "cli.ts"),
-				"context", "--dir", tmpDir, "--no-search", "--json",
+				"bun",
+				"run",
+				path.join(__dirname, "..", "src", "cli.ts"),
+				"context",
+				"--dir",
+				tmpDir,
+				"--no-search",
+				"--json",
 			],
 			{ stdout: "pipe", stderr: "pipe" },
 		);
@@ -376,8 +398,16 @@ describe("CLI subprocess", () => {
 		// Add
 		const addResult = Bun.spawnSync(
 			[
-				"bun", "run", path.join(__dirname, "..", "src", "cli.ts"),
-				"scratchpad", "add", "--dir", tmpDir, "--text", "Test task", "--json",
+				"bun",
+				"run",
+				path.join(__dirname, "..", "src", "cli.ts"),
+				"scratchpad",
+				"add",
+				"--dir",
+				tmpDir,
+				"--text",
+				"Test task",
+				"--json",
 			],
 			{ stdout: "pipe", stderr: "pipe" },
 		);
@@ -387,10 +417,7 @@ describe("CLI subprocess", () => {
 
 		// List
 		const listResult = Bun.spawnSync(
-			[
-				"bun", "run", path.join(__dirname, "..", "src", "cli.ts"),
-				"scratchpad", "list", "--dir", tmpDir, "--json",
-			],
+			["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "scratchpad", "list", "--dir", tmpDir, "--json"],
 			{ stdout: "pipe", stderr: "pipe" },
 		);
 		expect(listResult.exitCode).toBe(0);
@@ -400,10 +427,10 @@ describe("CLI subprocess", () => {
 	});
 
 	test("help shows usage", async () => {
-		const result = Bun.spawnSync(
-			["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "help"],
-			{ stdout: "pipe", stderr: "pipe" },
-		);
+		const result = Bun.spawnSync(["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "help"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
 		expect(result.exitCode).toBe(0);
 		const out = result.stdout.toString();
 		expect(out).toContain("agent-memory");
@@ -411,10 +438,10 @@ describe("CLI subprocess", () => {
 	});
 
 	test("unknown command exits with error", async () => {
-		const result = Bun.spawnSync(
-			["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "invalid", "--json"],
-			{ stdout: "pipe", stderr: "pipe" },
-		);
+		const result = Bun.spawnSync(["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "invalid", "--json"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
 		expect(result.exitCode).toBe(1);
 	});
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": false,
+		"outDir": "dist",
+		"rootDir": "src",
+		"declaration": true
+	}
+}


### PR DESCRIPTION
## Summary
- add PowerShell skill installer for Windows and document Windows install paths
- improve install script messaging to link CLI binary when available
- add buildable library output (tsconfig.build.json) with package exports/prepack updates
- minor CLI/core/test formatting cleanups

## Testing
- Not run