### PR TITLE
chore: release 0.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.13] - 2026-08-10
+
 ### Added
 - External-feedback evaluation dataset with deterministic capability probes, isolated multilingual qmd retrieval, and explicit qualitative boundaries
 - `eval:feedback` and `test:eval` commands for running and validating the feedback evaluation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "myagentmemory",
-	"version": "0.4.12",
+	"version": "0.4.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "myagentmemory",
-			"version": "0.4.12",
+			"version": "0.4.13",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "myagentmemory",
-	"version": "0.4.12",
+	"version": "0.4.13",
 	"description": "agentmemory (agent-memory) is persistent memory for coding agents (Claude Code, OpenAI Codex, Cursor, Agent) with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "./dist/core.js",
 	"types": "./dist/core.d.ts",


### PR DESCRIPTION
## Summary
- bump `myagentmemory` from 0.4.12 to 0.4.13
- move the accumulated Unreleased changes into the dated 0.4.13 changelog section
- prepare publication of the portable Node.js CLI that fixes #4

## Tests
- `bun test test/unit.test.ts`
- `bun test test/cli.test.ts`
- `bun test test/eval.test.ts`
- `bun run lint`
- `bun run build`

## Release behavior
After merge, tag `v0.4.13` will trigger the npm publish workflow. A successful npm publish will trigger the Homebrew formula update workflow.