### PR TITLE
fix: update Homebrew formula release automation

### DIFF
--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -70,9 +70,20 @@ jobs:
           version = "${{ steps.meta.outputs.version }}"
           path = Path("Formula/agent-memory.rb")
           text = path.read_text()
-          text = re.sub(r'^\\turl ".*"$', f'\\turl "{url}"', text, flags=re.M)
-          text = re.sub(r'^\\tsha256 ".*"$', f'\\tsha256 "{sha}"', text, flags=re.M)
-          text = re.sub(r'^\\tversion ".*"$', f'\\tversion "{version}"', text, flags=re.M)
+
+          def replace_field(content, field, value):
+              pattern = re.compile(rf'^(\s*){re.escape(field)}\s+".*"$', re.M)
+              updated, count = pattern.subn(
+                  lambda match: f'{match.group(1)}{field} "{value}"',
+                  content,
+              )
+              if count != 1:
+                  raise RuntimeError(f"Expected exactly one {field} field, found {count}")
+              return updated
+
+          text = replace_field(text, "url", url)
+          text = replace_field(text, "sha256", sha)
+          text = replace_field(text, "version", version)
           path.write_text(text)
           PY
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Made the Homebrew update workflow match formula fields regardless of indentation and fail when expected fields are missing
+
 ## [0.4.13] - 2026-08-10
 
 ### Added

--- a/Formula/agent-memory.rb
+++ b/Formula/agent-memory.rb
@@ -1,9 +1,9 @@
 class AgentMemory < Formula
   desc "agentmemory CLI: persistent memory for coding agents with qmd semantic search"
   homepage "https://github.com/jayzeng/agentmemory"
-  url "https://github.com/jayzeng/agentmemory/archive/refs/tags/v0.4.10.tar.gz"
-  sha256 "2b8493e997e5f3617f81cb4162015d78bd573e7c1ff6361f7c22bf015db9f3ab"
-  version "0.4.10"
+  url "https://github.com/jayzeng/agentmemory/archive/refs/tags/v0.4.13.tar.gz"
+  sha256 "f5a8ffe0989661ad2846d30d154a906b7c23c9b89b324462656bd0d6c4f790d1"
+  version "0.4.13"
   license "MIT"
 
   depends_on "bun" => :build


### PR DESCRIPTION
## Summary
- update the Homebrew formula to v0.4.13 with the verified source tarball checksum
- fix the updater's escaped-tab regex so it matches the formula's actual indentation
- fail the workflow unless each expected formula field is replaced exactly once

## Tests
- `ruby -c Formula/agent-memory.rb`
- local updater substitution assertion
- `bun test test/unit.test.ts`
- `bun test test/cli.test.ts`
- `bun test test/eval.test.ts`
- `bun run lint`
- `bun run build`