### PR TITLE
feat: ship official plugin runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -22,10 +22,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build
@@ -33,14 +33,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
       - run: npm ci
       - run: npm run test:unit
       - run: npm run test:cli
+      - run: npm run test:eval

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,22 +8,23 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
-          cache: npm
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
+      - run: npm install --global npm@12.0.2
+      - run: npm --version
       - run: npm ci
       - name: Verify tag matches package.json version
         shell: bash
@@ -44,5 +45,8 @@ jobs:
           fi
       - run: npm run lint
       - run: npm run build
-      - run: npm test
-      - run: npm publish
+      - run: npm run test:unit
+      - run: npm run test:cli
+      - run: npm run test:eval
+      - run: npm audit --audit-level=moderate
+      - run: npm publish --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Versioned public plugin-host types and manifest validation through the `myagentmemory/plugin-host` export
+- Plan-neutral capability grants, device-local quota policy, and per-command/hook capability requirements in plugin-host API v1
 - Fail-closed official-plugin bootstrap commands, signed Ed25519 release verification, bounded package validation, atomic install/upgrade/rollback, explicit uninstall, and deterministic regression coverage
 - Core-owned managed SessionStart hook installation for Claude Code, Codex, Cursor, and OpenCode
 - Bash, Zsh, Fish, and PowerShell completion generation and idempotent installation through public exports
 
 ### Changed
 - `agent-memory init`, `status`, and help now expose non-blocking optional-plugin discovery without affecting core memory behavior or opening a browser
+- Separate commercial plan identifiers from locally derived active/grace/missing/expired entitlement states
 
 ### Fixed
 - Made the Homebrew update workflow match formula fields regardless of indentation and fail when expected fields are missing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.14] - 2026-08-17
+
 ### Added
 - Versioned public plugin-host types and manifest validation through the `myagentmemory/plugin-host` export
 - Plan-neutral capability grants, device-local quota policy, and per-command/hook capability requirements in plugin-host API v1
 - Fail-closed official-plugin bootstrap commands, signed Ed25519 release verification, bounded package validation, atomic install/upgrade/rollback, explicit uninstall, and deterministic regression coverage
+- Temporary loopback email activation with a permission-restricted local record, unlimited capability grants, live commercial catalog/artifact retrieval, installed-bundle health checks, and paid-command dispatch
+- Official plugin runtime loading with manifest validation, shared bundle state, per-command capability enforcement, memory host APIs, abort handling, and Web Console support
 - Core-owned managed SessionStart hook installation for Claude Code, Codex, Cursor, and OpenCode
 - Bash, Zsh, Fish, and PowerShell completion generation and idempotent installation through public exports
 
 ### Changed
 - `agent-memory init`, `status`, and help now expose non-blocking optional-plugin discovery without affecting core memory behavior or opening a browser
 - Separate commercial plan identifiers from locally derived active/grace/missing/expired entitlement states
+- Clarify that AgentMemory core remains free and MIT-licensed while optional plugin implementations are distributed separately under their own terms
+- Run unit, CLI/package-portability, and evaluation suites before npm publication
+- Made Pro discovery, install, upgrade, and current-version output explain the included Session Intelligence, guided learning, local Web Console, privacy boundary, and useful next commands
+- Sent an explicit, bounded Pro activation record to the private control plane with transparent browser disclosure; the payload excludes memory, sessions, queries, paths, IP addresses, and user-agent strings
 
 ### Fixed
+- Expose the real core memory directory to permission-checked first-party plugins so local interfaces do not confuse plugin operational state with user memory
+- Accepted same-origin loopback activation forms from browsers that omit `Origin` or serialize it as `null`, while preserving nonce/Host validation and rejecting cross-origin requests
+- Reload local entitlement state before every installed-plugin command and bound error responses from the plugin service
+- Replace unsafe TLS-disable installation guidance with corporate CA-file configuration
 - Made the Homebrew update workflow match formula fields regardless of indentation and fail when expected fields are missing
 - Build public `dist` exports during commit-pinned Git dependency installation
 - Allow host adapters to write through the core memory contract to an explicit directory without mutating process-global core state

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Coding-agent sessions preserve activity. They do not decide which facts, decisio
 
 ### Product boundary
 
-AgentMemory is a local Markdown store with a CLI, optional qmd search, and agent skills. It does not automatically import every vendor transcript or silently decide what becomes durable. It is not a Python SDK, vector database, or knowledge graph. The Markdown files remain the source of truth.
+AgentMemory is free, open-source software under the MIT License. The core is a local Markdown store with a CLI, optional qmd search, and agent skills, and it remains fully usable without an account or commercial plugin. It does not automatically import every vendor transcript or silently decide what becomes durable. It is not a Python SDK, vector database, or knowledge graph. The Markdown files remain the source of truth.
 
 ### Optional official plugins
 
-The core can discover and host separately distributed, signed first-party plugins while remaining fully useful on its own. `agent-memory plugin list` and `plugin status` report local state. The idempotent `agent-memory plugin install` state machine verifies signed release metadata, validates bounded packages, and installs or upgrades atomically. Commercial authentication and downloads remain fail-closed until the production service and signing keys are configured. See the [official plugin bootstrap and host contract](docs/official-plugin-bootstrap.md).
+The MIT-licensed core can discover and host separately distributed, signed first-party plugins while remaining fully useful on its own. Optional plugins may use their own license and distribution terms; their implementation and browser assets are not part of the `myagentmemory` package. `agent-memory plugin list` and `plugin status` report local state. In an interactive terminal, `agent-memory plugin install` opens a nonce-bound loopback page for an email address, resumes the waiting command, verifies signed release metadata and the downloaded bundle, and installs atomically. This temporary beta grants unlimited local use. The email remains in a mode-0600 local activation record and is also sent with bounded activation metadata to the private commercial service; memory, sessions, queries, repository paths, IP addresses, and user-agent strings are not stored in the activation database. Authentication and payment will replace this temporary flow later. See the [official plugin bootstrap and host contract](docs/official-plugin-bootstrap.md).
 
 ## Installation
 
@@ -42,8 +42,8 @@ brew install jayzeng/agentmemory/agent-memory
 # Install the portable CLI globally (Node.js 20+; macOS, Linux, or Windows)
 npm install -g myagentmemory
 
-# If you hit SSL errors due to corporate MITM/inspection, try:
-# npm config set strict-ssl false
+# If corporate TLS inspection requires a private CA, use your organization's CA file:
+# npm config set cafile /path/to/corporate-ca.pem
 
 # Or build from source
 bun run build:cli
@@ -284,16 +284,7 @@ agent-memory install-skills
 
 ## Publishing (maintainers)
 
-```bash
-# Confirm package name is available
-npm view myagentmemory
-
-# Bump version (choose patch/minor/major)
-npm version patch
-
-# Publish to npm (public)
-npm publish --access public
-```
+Publication is tag-driven through `.github/workflows/publish-npm.yml`. Configure `jayzeng/agentmemory` and `publish-npm.yml` as the npm trusted publisher for `myagentmemory`, merge a versioned changelog/package update, and push the matching `v<version>` tag. The workflow uses short-lived OIDC credentials, runs the complete release gate, and publishes the public package with provenance. Do not publish this package from the private plugin workspace.
 
 ### Repository assets (maintainers)
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
     },
   },
   "overrides": {
+    "esbuild": "^0.28.1",
     "glob": "^13.0.3",
     "rimraf": "^6.1.3",
   },
@@ -36,57 +37,57 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-g47s+V+OqsGxbSZN3lpav6WYOk0PIc3aCBAq+p6dwSynL3K5MA6Cg6nkzDOlu28GEHwbakW+BllzHCJCxnfK5Q=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.2", "", { "os": "android", "cpu": "arm" }, "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.2", "", { "os": "android", "cpu": "arm64" }, "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.2", "", { "os": "android", "cpu": "x64" }, "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.2", "", { "os": "linux", "cpu": "arm" }, "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.2", "", { "os": "linux", "cpu": "none" }, "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.2", "", { "os": "linux", "cpu": "x64" }, "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.2", "", { "os": "none", "cpu": "arm64" }, "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.2", "", { "os": "none", "cpu": "x64" }, "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.2", "", { "os": "none", "cpu": "arm64" }, "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -94,7 +95,7 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": "bin/esbuild" }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+    "esbuild": ["esbuild@0.28.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.2", "@esbuild/android-arm": "0.28.2", "@esbuild/android-arm64": "0.28.2", "@esbuild/android-x64": "0.28.2", "@esbuild/darwin-arm64": "0.28.2", "@esbuild/darwin-x64": "0.28.2", "@esbuild/freebsd-arm64": "0.28.2", "@esbuild/freebsd-x64": "0.28.2", "@esbuild/linux-arm": "0.28.2", "@esbuild/linux-arm64": "0.28.2", "@esbuild/linux-ia32": "0.28.2", "@esbuild/linux-loong64": "0.28.2", "@esbuild/linux-mips64el": "0.28.2", "@esbuild/linux-ppc64": "0.28.2", "@esbuild/linux-riscv64": "0.28.2", "@esbuild/linux-s390x": "0.28.2", "@esbuild/linux-x64": "0.28.2", "@esbuild/netbsd-arm64": "0.28.2", "@esbuild/netbsd-x64": "0.28.2", "@esbuild/openbsd-arm64": "0.28.2", "@esbuild/openbsd-x64": "0.28.2", "@esbuild/openharmony-arm64": "0.28.2", "@esbuild/sunos-x64": "0.28.2", "@esbuild/win32-arm64": "0.28.2", "@esbuild/win32-ia32": "0.28.2", "@esbuild/win32-x64": "0.28.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 

--- a/docs/official-plugin-bootstrap.md
+++ b/docs/official-plugin-bootstrap.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Accepted design on 2026-08-16. Stage 2 is implemented in the public core: host types, local discovery, signed-release verification, bounded package validation, and transactional install/rollback are available. Production authentication, catalog, download, and signing-key configuration remain intentionally unavailable until the commercial service is implemented.
+Accepted design on 2026-08-16. The public core now implements host types, temporary loopback activation, live catalog and artifact retrieval, Ed25519 release verification, bounded package validation, transactional install, bundle health checks, and paid-command dispatch. The temporary beta grants unlimited local use after email entry; durable authentication, payment, renewal, and account management remain deferred.
 
-The public `agentmemory` repository and `myagentmemory` npm package remain the MIT-licensed core. Official commercial implementations are built and distributed from the private `agent-memory-plugin` workspace. Pricing, the billing provider, the service hostname, device limits, offline-grace duration, and Enterprise contract terms are intentionally not decided here.
+The public `agentmemory` repository and `myagentmemory` npm package remain the free, MIT-licensed core. The public bootstrap client and host contracts are also MIT-licensed. Official commercial implementations and browser assets are built and distributed separately from the private `agent-memory-plugin` workspace under their own terms. Pricing, the billing provider, device limits, offline-grace duration, and Enterprise contract terms are intentionally not decided here. The temporary beta currently uses allowlisted `*.agentmemory.paperpilot.me` service origins; changing those origins is a public-client release change.
 
 ## Decision
 
@@ -23,11 +23,11 @@ agent-memory plugin install
 | Plugin absent | Active or grace | Install the compatible signed bundle |
 | Plugin older than the selected release | Active or grace | Upgrade atomically |
 | Plugin current | Active or grace | Report that it is current |
-| Any | Missing | Start authentication and plan selection |
+| Any | Missing | Start temporary loopback email activation in an interactive terminal |
 | Any | Expired | Direct the user to renewal; leave core available |
 | Incompatible bundle | Any | Leave the current version untouched and explain the required core version |
 
-An absent plugin cannot validate a commercial license. The public bootstrap performs the initial authenticated entitlement lookup and artifact verification. After activation, the private runtime validates a signed local entitlement before any paid entry point runs.
+An absent plugin cannot activate itself. The public bootstrap performs temporary local activation, obtains a short-lived artifact grant, and verifies the release and artifact. After installation, the public host validates the local activation record and checks the required capability before every paid command. Signed long-lived entitlements will replace this temporary record when authentication and payment ship.
 
 ## Ownership boundary
 
@@ -81,10 +81,10 @@ agent-memory plugin manage [--no-browser]
 - `status` is read-only. It reports the installed bundle, selected channel, compatibility, entitlement state, and update availability.
 - `install` authenticates when necessary, then installs, upgrades, or reports current state.
 - `update` requires an existing installation and never starts a new purchase implicitly.
-- `uninstall` removes executable plugin material, contributed skills, and managed hooks. It preserves core memory, private plugin-created user data, and the subscription.
-- `manage` opens or prints the authenticated account and billing URL.
+- `uninstall` removes executable plugin material and the active receipt. It preserves core memory, plugin state, and the temporary activation record.
+- `manage` remains unavailable until authenticated account and billing management exists.
 
-Installed plugins may contribute additional subcommands such as `plugin recall`. Bootstrap command names are reserved by the core and cannot be replaced by a plugin.
+Installed plugins contribute top-level commands such as `recall`, `learn`, `worker`, and `web`. Bootstrap command names are reserved by the core and cannot be replaced by a plugin.
 
 The current private compatibility CLI uses `plugin install` and `plugin uninstall` for skill files only. During migration, those meanings move to `install-skills --plugin-only` and `uninstall-skills --plugin-only`; the bootstrap command names above become authoritative.
 
@@ -99,7 +99,7 @@ Run: agent-memory plugin install
 
 Top-level help includes an `Optional official plugins` section. Human-readable `status` may include the same recommendation while no official plugin is installed. Routine `context`, `read`, `write`, `search`, and scratchpad commands never show commercial prompts.
 
-The core must not open a browser during package installation, `init`, `help`, `status`, or any normal memory operation. A browser may open only after an explicit `plugin install` or `plugin manage` invocation. `--no-browser`, non-interactive execution, and `--json` print the URL instead.
+The core must not open a browser during package installation, `init`, `help`, `status`, or any normal memory operation. A browser may open only after an explicit interactive `plugin install`. `--no-browser`, non-interactive execution, and `--json` fail closed with `auth_required` when no activation record exists.
 
 ### Machine-readable output
 
@@ -133,7 +133,18 @@ Every bootstrap command supports `--json` and emits one JSON document with a ver
 
 `result` is one of `not_installed`, `installed`, `upgraded`, `current`, `update_available`, `uninstalled`, `auth_required`, `renewal_required`, or `unavailable`. Failures use `ok: false` plus a stable `error.code` and redacted `error.message`. Output must never contain access tokens, download credentials, signed entitlement contents, local memory paths, or URLs containing bearer credentials.
 
-## Authentication and purchase flow
+## Temporary activation flow
+
+1. `agent-memory plugin install` starts an HTTP server bound to `127.0.0.1` on an ephemeral port.
+2. The CLI prints and opens a nonce-bearing local URL. The page accepts one email address with bounded input, an exact Host and nonce path, same-origin browser request validation, restrictive response headers, and a five-minute deadline.
+3. Submission writes a mode-0600 record under the plugin install root and returns a completion page.
+4. The waiting CLI sends the email plus core, installed-bundle, platform, architecture, release-channel, and consent-version fields to the private control plane. Its activation database stores none of the user's memory, sessions, queries, repository paths, IP address, or user-agent string, and deletes records after 365 days without activation.
+5. The CLI requests temporary unlimited capabilities and a short-lived object-bound artifact grant, verifies the Ed25519-signed release plus package digest and limits, imports it for health checks, then atomically activates the receipt.
+6. Installed paid commands reload the local entitlement and enforce their declared capability before execution.
+
+This is explicitly temporary. Authentication, payment, renewal, account management, server-side entitlement state, and durable credential storage are not implemented yet.
+
+## Future authentication and purchase flow
 
 1. The bootstrap inspects the local install receipt and signed entitlement without loading plugin code.
 2. If no usable entitlement or account credential exists, it requests a short-lived device authorization.
@@ -149,7 +160,13 @@ An Enterprise administrator may pre-provision an organization entitlement or man
 
 ## Control-plane boundary
 
-Endpoint names are illustrative until the service is selected, but the protocol responsibilities are fixed:
+The temporary service exposes:
+
+- `POST /v1/plugin/access` for unlimited temporary capability grants plus a short-lived artifact grant;
+- `GET /v1/plugin/releases` for an Ed25519-signed release selected from the private R2 catalog;
+- `GET|HEAD /v1/artifacts/download` for the exact content-addressed object authorized by the bearer grant.
+
+The temporary access request contains the submitted email plus the bounded core, bundle, platform, architecture, release-channel, and consent-version fields described above. Its application payload contains no memory content, search query, session content, path, repository name, qmd data, IP address, user-agent string, or plugin-derived metric; the activation database stores neither IP addresses nor user-agent strings. Future authenticated service responsibilities include:
 
 - create and poll a device authorization;
 - read the authenticated principal's effective entitlement;
@@ -273,13 +290,15 @@ export interface AgentMemoryPluginHostV1 {
 }
 ```
 
-The final exported contract must define the referenced request, result, command, hook, manifest, entitlement-status, permission, cancellation, and structured-error types. Commercial manifests are plan-neutral: they declare `entitlement: "commercial"`, their provided capabilities, and the `requiredCapability` for each guarded command or hook. The loader validates every bundled plugin first, then creates a host instance scoped to that plugin's manifest. Host methods enforce its declared permissions. Plugins receive only derived entitlement state, capability grants, quota policy, and time bounds, never raw signed claims or commercial credentials. They also never receive unrestricted core internals, arbitrary command execution, or ambient access to another plugin's state directory.
+The final exported contract must define the referenced request, result, command, hook, manifest, entitlement-status, permission, cancellation, and structured-error types. Commercial manifests are plan-neutral: they declare `entitlement: "commercial"`, their provided capabilities, and the `requiredCapability` for each guarded command or hook. The loader validates every bundled plugin first, then creates a host instance scoped to that plugin's manifest. Host methods enforce its declared permissions. Plugins receive only derived entitlement state, capability grants, quota policy, and time bounds through host APIs, never raw signed claims or commercial credentials.
+
+Installed bundles are trusted, signed first-party JavaScript loaded into the AgentMemory process. Manifest permissions constrain host APIs; they are not an operating-system sandbox and do not remove the bundle's ambient Node.js process or filesystem authority. This contract does not approve arbitrary third-party plugin loading. State-directory isolation prevents accidental host-API crossover, not malicious code running in the same process.
 
 Activation order is: verify artifact, verify entitlement, validate every manifest, resolve required dependencies, create permission-scoped host adapters, activate plugins, then register commands and hooks. Registered-but-unavailable dependencies do not satisfy `requires`.
 
 ## Runtime entitlement behavior
 
-Every commercial command, compatibility alias, hook, worker start, Web Console launch, and commercial API route checks both entitlement state and its exact required capability before activation. A long-running process rechecks at a bounded interval and responds safely to expiration or capability removal. Browser-session authorization remains separate from commercial entitlement and never contains subscription credentials.
+The core reloads local entitlement state before every commercial command or compatibility alias and checks its exact required capability before dispatch. Plugin-owned hooks, worker starts, Web Console launches, and commercial API routes must perform the same check through `host.getEntitlement()`. A long-running plugin process must recheck through that host API at a bounded interval and respond safely to expiration or capability removal. Browser-session authorization remains separate from commercial entitlement and never contains subscription credentials.
 
 When entitlement is in grace, paid capabilities continue locally and status explains when grace ends. When expired or invalid, new paid work fails closed with a renewal action; core memory remains available and no user data is deleted.
 

--- a/docs/official-plugin-bootstrap.md
+++ b/docs/official-plugin-bootstrap.md
@@ -120,6 +120,10 @@ Every bootstrap command supports `--json` and emits one JSON document with a ver
   "entitlement": {
     "plan": "pro",
     "state": "active",
+    "capabilities": {
+      "learning": { "enabled": true },
+      "web-console": { "enabled": true }
+    },
     "expiresAt": "2027-08-16T00:00:00Z",
     "offlineUntil": "2026-09-15T00:00:00Z"
   },
@@ -176,6 +180,10 @@ The server issues a signed, versioned entitlement containing the minimum claims 
   "licenseId": "lic_pseudonymous_id",
   "plan": "pro",
   "features": ["session-intelligence", "web-console"],
+  "capabilities": {
+    "learning": { "enabled": true },
+    "web-console": { "enabled": true }
+  },
   "channel": "stable",
   "issuedAt": "2026-08-16T00:00:00Z",
   "refreshAfter": "2026-08-23T00:00:00Z",
@@ -184,7 +192,9 @@ The server issues a signed, versioned entitlement containing the minimum claims 
 }
 ```
 
-It contains no name, email address, billing details, memory identifier, or filesystem information. `active`, `grace`, and `expired` are derived locally from verified timestamps and policy; they are not trusted from an unsigned local setting. Enterprise may satisfy all `pro` feature requirements while adding organization-scoped policy claims.
+It contains no name, email address, billing details, memory identifier, or filesystem information. Plan identifiers (`free`, `trial`, `pro`, `team`, or `enterprise`) are commercial policy; `active`, `grace`, `missing`, and `expired` are separate locally derived verification states and are never inferred from the plan name. Enterprise may satisfy all `pro` capability requirements while adding organization-scoped policy claims.
+
+Capabilities authorize individual commands, hooks, workers, and local API routes. A capability may carry a positive device-local daily quota. The signed policy configures the limit, while usage remains in a crash-safe local ledger; quota accounting does not add product telemetry to the bootstrap protocol. A plan never implicitly enables a capability, and an active entitlement with a disabled or absent capability fails closed for that operation.
 
 The exact signed-envelope format, key custody, rotation procedure, and grace duration remain launch decisions. Verification keys are pinned by the public core, support overlap during rotation, and never come from the downloaded artifact being verified.
 
@@ -263,13 +273,13 @@ export interface AgentMemoryPluginHostV1 {
 }
 ```
 
-The final exported contract must define the referenced request, result, command, hook, manifest, entitlement-status, permission, cancellation, and structured-error types. The loader validates every bundled plugin first, then creates a host instance scoped to that plugin's manifest. Host methods enforce its declared permissions. Plugins receive only derived entitlement state and time bounds, never raw signed claims or commercial credentials. They also never receive unrestricted core internals, arbitrary command execution, or ambient access to another plugin's state directory.
+The final exported contract must define the referenced request, result, command, hook, manifest, entitlement-status, permission, cancellation, and structured-error types. Commercial manifests are plan-neutral: they declare `entitlement: "commercial"`, their provided capabilities, and the `requiredCapability` for each guarded command or hook. The loader validates every bundled plugin first, then creates a host instance scoped to that plugin's manifest. Host methods enforce its declared permissions. Plugins receive only derived entitlement state, capability grants, quota policy, and time bounds, never raw signed claims or commercial credentials. They also never receive unrestricted core internals, arbitrary command execution, or ambient access to another plugin's state directory.
 
 Activation order is: verify artifact, verify entitlement, validate every manifest, resolve required dependencies, create permission-scoped host adapters, activate plugins, then register commands and hooks. Registered-but-unavailable dependencies do not satisfy `requires`.
 
 ## Runtime entitlement behavior
 
-Every paid command, compatibility alias, hook, worker start, Web Console launch, and paid API route checks entitlement before activation. A long-running process rechecks at a bounded interval and responds safely to expiration. Browser-session authorization remains separate from commercial entitlement and never contains subscription credentials.
+Every commercial command, compatibility alias, hook, worker start, Web Console launch, and commercial API route checks both entitlement state and its exact required capability before activation. A long-running process rechecks at a bounded interval and responds safely to expiration or capability removal. Browser-session authorization remains separate from commercial entitlement and never contains subscription credentials.
 
 When entitlement is in grace, paid capabilities continue locally and status explains when grace ends. When expired or invalid, new paid work fails closed with a renewal action; core memory remains available and no user data is deleted.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "myagentmemory",
-	"version": "0.4.13",
+	"version": "0.4.14",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "myagentmemory",
-			"version": "0.4.13",
+			"version": "0.4.14",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -187,9 +187,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+			"integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -204,9 +204,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+			"integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
 			"cpu": [
 				"arm"
 			],
@@ -221,9 +221,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+			"integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
 			"cpu": [
 				"arm64"
 			],
@@ -238,9 +238,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+			"integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
 			"cpu": [
 				"x64"
 			],
@@ -255,9 +255,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+			"integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
 			"cpu": [
 				"arm64"
 			],
@@ -272,9 +272,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+			"integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
 			"cpu": [
 				"x64"
 			],
@@ -289,9 +289,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -306,9 +306,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+			"integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
 			"cpu": [
 				"x64"
 			],
@@ -323,9 +323,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+			"integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
 			"cpu": [
 				"arm"
 			],
@@ -340,9 +340,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+			"integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
 			"cpu": [
 				"arm64"
 			],
@@ -357,9 +357,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+			"integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -374,9 +374,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+			"integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -391,9 +391,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+			"integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -408,9 +408,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+			"integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -425,9 +425,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+			"integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -442,9 +442,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+			"integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
 			"cpu": [
 				"s390x"
 			],
@@ -459,9 +459,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+			"integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
 			"cpu": [
 				"x64"
 			],
@@ -476,9 +476,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
 			"cpu": [
 				"arm64"
 			],
@@ -493,9 +493,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
 			"cpu": [
 				"x64"
 			],
@@ -510,9 +510,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -527,9 +527,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
 			"cpu": [
 				"x64"
 			],
@@ -544,9 +544,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+			"integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -561,9 +561,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+			"integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
 			"cpu": [
 				"x64"
 			],
@@ -578,9 +578,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+			"integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -595,9 +595,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+			"integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
 			"cpu": [
 				"ia32"
 			],
@@ -612,9 +612,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+			"integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
 			"cpu": [
 				"x64"
 			],
@@ -659,9 +659,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -672,32 +672,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.3",
-				"@esbuild/android-arm": "0.27.3",
-				"@esbuild/android-arm64": "0.27.3",
-				"@esbuild/android-x64": "0.27.3",
-				"@esbuild/darwin-arm64": "0.27.3",
-				"@esbuild/darwin-x64": "0.27.3",
-				"@esbuild/freebsd-arm64": "0.27.3",
-				"@esbuild/freebsd-x64": "0.27.3",
-				"@esbuild/linux-arm": "0.27.3",
-				"@esbuild/linux-arm64": "0.27.3",
-				"@esbuild/linux-ia32": "0.27.3",
-				"@esbuild/linux-loong64": "0.27.3",
-				"@esbuild/linux-mips64el": "0.27.3",
-				"@esbuild/linux-ppc64": "0.27.3",
-				"@esbuild/linux-riscv64": "0.27.3",
-				"@esbuild/linux-s390x": "0.27.3",
-				"@esbuild/linux-x64": "0.27.3",
-				"@esbuild/netbsd-arm64": "0.27.3",
-				"@esbuild/netbsd-x64": "0.27.3",
-				"@esbuild/openbsd-arm64": "0.27.3",
-				"@esbuild/openbsd-x64": "0.27.3",
-				"@esbuild/openharmony-arm64": "0.27.3",
-				"@esbuild/sunos-x64": "0.27.3",
-				"@esbuild/win32-arm64": "0.27.3",
-				"@esbuild/win32-ia32": "0.27.3",
-				"@esbuild/win32-x64": "0.27.3"
+				"@esbuild/aix-ppc64": "0.28.2",
+				"@esbuild/android-arm": "0.28.2",
+				"@esbuild/android-arm64": "0.28.2",
+				"@esbuild/android-x64": "0.28.2",
+				"@esbuild/darwin-arm64": "0.28.2",
+				"@esbuild/darwin-x64": "0.28.2",
+				"@esbuild/freebsd-arm64": "0.28.2",
+				"@esbuild/freebsd-x64": "0.28.2",
+				"@esbuild/linux-arm": "0.28.2",
+				"@esbuild/linux-arm64": "0.28.2",
+				"@esbuild/linux-ia32": "0.28.2",
+				"@esbuild/linux-loong64": "0.28.2",
+				"@esbuild/linux-mips64el": "0.28.2",
+				"@esbuild/linux-ppc64": "0.28.2",
+				"@esbuild/linux-riscv64": "0.28.2",
+				"@esbuild/linux-s390x": "0.28.2",
+				"@esbuild/linux-x64": "0.28.2",
+				"@esbuild/netbsd-arm64": "0.28.2",
+				"@esbuild/netbsd-x64": "0.28.2",
+				"@esbuild/openbsd-arm64": "0.28.2",
+				"@esbuild/openbsd-x64": "0.28.2",
+				"@esbuild/openharmony-arm64": "0.28.2",
+				"@esbuild/sunos-x64": "0.28.2",
+				"@esbuild/win32-arm64": "0.28.2",
+				"@esbuild/win32-ia32": "0.28.2",
+				"@esbuild/win32-x64": "0.28.2"
 			}
 		},
 		"node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "myagentmemory",
-	"version": "0.4.13",
+	"version": "0.4.14",
 	"description": "agentmemory (agent-memory) is persistent memory for coding agents (Claude Code, OpenAI Codex, Cursor, Agent) with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "./dist/core.js",
 	"types": "./dist/core.d.ts",
@@ -82,6 +82,11 @@
 		"dist/plugin-bootstrap.js",
 		"dist/plugin-host.d.ts",
 		"dist/plugin-host.js",
+		"dist/plugin-runtime.d.ts",
+		"dist/plugin-runtime.js",
+		"dist/plugin-service.d.ts",
+		"dist/plugin-service.js",
+		"docs/official-plugin-bootstrap.md",
 		"README.md",
 		"LICENSE"
 	],
@@ -112,6 +117,7 @@
 		"typescript": "^5.9.3"
 	},
 	"overrides": {
+		"esbuild": "^0.28.1",
 		"rimraf": "^6.1.3",
 		"glob": "^13.0.3"
 	}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,6 +73,7 @@ import {
 	PluginBootstrapFailure,
 	type PluginBootstrapResultV1,
 } from "./plugin-bootstrap.js";
+import { InstalledPluginRuntimeV1 } from "./plugin-runtime.js";
 
 declare const __VERSION__: string;
 
@@ -183,6 +184,26 @@ function openExternalUrl(url: string): boolean {
 	}
 }
 
+function printProOverview(installed: boolean): void {
+	console.log("");
+	console.log("AgentMemory Pro includes:");
+	console.log("  Session Intelligence  Recall decisions and context across Pi, Codex, and Claude Code sessions.");
+	console.log("  Guided Learning       Turn repeated corrections into reviewable, reversible memory.");
+	console.log("  Local Web Console     Inspect memories, activity, health, and settings in your browser.");
+	console.log("");
+	console.log("Your session content stays on this device.");
+	console.log("");
+	if (installed) {
+		console.log("Try it:");
+		console.log('  agent-memory recall "what did we decide about authentication?"');
+		console.log("  agent-memory learn");
+		console.log("  agent-memory web");
+	} else {
+		console.log("Start your Pro beta:");
+		console.log("  agent-memory plugin install");
+	}
+}
+
 function printPluginResult(result: PluginBootstrapResultV1, json: boolean, allowBrowser: boolean): void {
 	if (json) {
 		output(result, true);
@@ -191,18 +212,26 @@ function printPluginResult(result: PluginBootstrapResultV1, json: boolean, allow
 			const state = plugin.available ? "available" : plugin.installed ? plugin.entitlement : "not installed";
 			console.log(`${plugin.name}: ${state}`);
 		}
-		if (result.result === "not_installed") console.log("\nInstall or activate: agent-memory plugin install");
+		printProOverview(Boolean(result.bundle));
 	} else {
 		const version = result.bundle?.version ? ` ${result.bundle.version}` : "";
+		let showOverview = false;
 		switch (result.result) {
 			case "installed":
 				console.log(`AgentMemory Pro${version} installed.`);
+				showOverview = true;
 				break;
 			case "upgraded":
 				console.log(`AgentMemory Pro upgraded to${version}.`);
+				showOverview = true;
 				break;
 			case "current":
-				console.log(result.bundle ? `AgentMemory Pro${version} is current.` : "AgentMemory Pro is not installed.");
+				console.log(
+					result.bundle
+						? `AgentMemory Pro${version} is installed and ready.`
+						: "AgentMemory Pro is not installed.",
+				);
+				showOverview = Boolean(result.bundle);
 				break;
 			case "update_available":
 				console.log(`AgentMemory Pro${version} has an update available.`);
@@ -215,7 +244,7 @@ function printPluginResult(result: PluginBootstrapResultV1, json: boolean, allow
 				console.log("Run: agent-memory plugin install");
 				break;
 			case "auth_required":
-				console.log("Sign in and choose a plan to continue.");
+				console.log("Run this command in an interactive terminal to enter an email and activate temporary access.");
 				break;
 			case "renewal_required":
 				console.log("Renew AgentMemory Pro to continue using paid capabilities.");
@@ -223,6 +252,7 @@ function printPluginResult(result: PluginBootstrapResultV1, json: boolean, allow
 			default:
 				console.log(result.error?.message ?? "AgentMemory Pro is currently unavailable.");
 		}
+		if (showOverview) printProOverview(true);
 	}
 
 	if (result.nextAction) {
@@ -969,9 +999,9 @@ Usage:
   agent-memory plugin uninstall --yes
   agent-memory plugin manage [--no-browser]
 
-The public core remains fully usable without AgentMemory Pro. Authentication and
-artifact downloads are unavailable until a production commercial service and
-release signing keys are configured.`);
+The public core remains fully usable without AgentMemory Pro. Interactive install
+opens a loopback website for temporary email activation and unlimited local use.
+Authentication and payment will be added later.`);
 }
 
 function pluginCommandFailure(command: string, error: unknown): PluginBootstrapResultV1 {
@@ -1015,8 +1045,8 @@ async function cmdPlugin(flags: Record<string, string | boolean>, positional: st
 		);
 		return;
 	}
-	const manager = createDefaultPluginBootstrap(VERSION);
 	const allowBrowser = !json && !hasFlag(flags, "no-browser") && Boolean(process.stdin.isTTY && process.stdout.isTTY);
+	const manager = createDefaultPluginBootstrap(VERSION);
 
 	let result: PluginBootstrapResultV1;
 	try {
@@ -1028,7 +1058,7 @@ async function cmdPlugin(flags: Record<string, string | boolean>, positional: st
 				result = await manager.status(channel);
 				break;
 			case "install":
-				result = await manager.install({ channel, allowAuthentication: true });
+				result = await manager.install({ channel, allowAuthentication: allowBrowser });
 				break;
 			case "update":
 				result = await manager.update({ channel, allowAuthentication: false });
@@ -1202,8 +1232,23 @@ async function main() {
 		case "plugin":
 			await cmdPlugin(flags, positional);
 			break;
-		default:
-			exitError(`Unknown command: ${command}. Run 'agent-memory help' for usage.`, json);
+		default: {
+			const controller = new AbortController();
+			const abort = () => controller.abort();
+			process.once("SIGINT", abort);
+			try {
+				const result = await new InstalledPluginRuntimeV1({ coreVersion: VERSION }).run(command, {
+					args: positional,
+					flags,
+					signal: controller.signal,
+				});
+				if (!result) exitError(`Unknown command: ${command}. Run 'agent-memory help' for usage.`, json);
+				if (!result.ok) exitError(result.error?.message ?? `Plugin command ${command} failed`, json);
+				output(result.data ?? { ok: true }, json);
+			} finally {
+				process.removeListener("SIGINT", abort);
+			}
+		}
 	}
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -985,6 +985,7 @@ function pluginCommandFailure(command: string, error: unknown): PluginBootstrapR
 			plan: null,
 			state: "missing",
 			features: [],
+			capabilities: {},
 		},
 		nextAction: null,
 		error: {

--- a/src/plugin-bootstrap.ts
+++ b/src/plugin-bootstrap.ts
@@ -10,6 +10,7 @@ import {
 	type PluginEntitlementStatusV1,
 	validateBundleManifestV1,
 } from "./plugin-host.js";
+import { TemporaryPluginBackend } from "./plugin-service.js";
 
 export const OFFICIAL_BUNDLE_ID = "agentmemory.pro";
 export const OFFICIAL_PLUGIN_IDS = ["agentmemory.session-intelligence", "agentmemory.web-console"] as const;
@@ -188,6 +189,9 @@ const OFFICIAL_PLUGINS = [
 const PACKAGE_MAX_BYTES = 64 * 1024 * 1024;
 const PACKAGE_MAX_EXPANDED_BYTES = 128 * 1024 * 1024;
 const PACKAGE_MAX_FILES = 10_000;
+const TEMPORARY_RELEASE_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEASefZFUVFy1EmvGbd0ckHZThmPgqQ3u9HCwZRReAZQW8=
+-----END PUBLIC KEY-----`;
 
 export class PluginBootstrapFailure extends Error {
 	constructor(
@@ -696,11 +700,17 @@ export class PluginBootstrapV1 {
 }
 
 export function createDefaultPluginBootstrap(coreVersion: string): PluginBootstrapV1 {
+	const store = new FilePluginInstallStore();
+	const backend = new TemporaryPluginBackend({ root: store.root, coreVersion });
 	return new PluginBootstrapV1({
 		coreVersion,
-		backend: new UnavailablePluginBackend(),
-		verifier: new RejectingReleaseVerifier(),
-		store: new FilePluginInstallStore(),
+		backend,
+		verifier: new Ed25519ReleaseVerifier({ "agentmemory-temporary-2026-08": TEMPORARY_RELEASE_PUBLIC_KEY }),
+		store,
+		healthCheck: async (directory, release) => {
+			const { createInstalledBundleHealthCheck } = await import("./plugin-runtime.js");
+			await createInstalledBundleHealthCheck(coreVersion, backend, store.root)(directory, release);
+		},
 	});
 }
 

--- a/src/plugin-bootstrap.ts
+++ b/src/plugin-bootstrap.ts
@@ -176,6 +176,7 @@ const MISSING_ENTITLEMENT: PluginEntitlementStatusV1 = {
 	plan: null,
 	state: "missing",
 	features: [],
+	capabilities: {},
 	reason: "No signed AgentMemory commercial entitlement is installed",
 };
 

--- a/src/plugin-host.ts
+++ b/src/plugin-host.ts
@@ -12,10 +12,24 @@ export type PluginPermissionV1 =
 
 export type PluginEntitlementStateV1 = "active" | "grace" | "missing" | "expired";
 
+export type PluginPlanV1 = "free" | "trial" | "pro" | "team" | "enterprise";
+
+export interface PluginCapabilityQuotaV1 {
+	limit: number;
+	window: "day";
+	scope: "device";
+}
+
+export interface PluginCapabilityGrantV1 {
+	enabled: boolean;
+	quota?: PluginCapabilityQuotaV1;
+}
+
 export interface PluginEntitlementStatusV1 {
-	plan: "pro" | "enterprise" | null;
+	plan: PluginPlanV1 | null;
 	state: PluginEntitlementStateV1;
 	features: string[];
+	capabilities: Record<string, PluginCapabilityGrantV1>;
 	expiresAt?: string;
 	offlineUntil?: string;
 	reason?: string;
@@ -25,6 +39,7 @@ export interface PluginCommandDescriptorV1 {
 	name: string;
 	description: string;
 	aliases?: string[];
+	requiredCapability: string;
 }
 
 export interface AgentMemoryPluginManifestV1 {
@@ -34,7 +49,7 @@ export interface AgentMemoryPluginManifestV1 {
 	version: string;
 	description: string;
 	engine: string;
-	entitlement: "pro";
+	entitlement: "commercial";
 	commands: PluginCommandDescriptorV1[];
 	permissions: PluginPermissionV1[];
 	requires?: string[];
@@ -77,6 +92,7 @@ export interface PluginSessionStartContextV1 {
 
 export interface PluginSessionStartHookV1 {
 	name: string;
+	requiredCapability: string;
 	run(context: PluginSessionStartContextV1): Promise<void>;
 }
 
@@ -143,6 +159,8 @@ export interface AgentMemoryPluginBundleV1 {
 const PLUGIN_ID = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/;
 const COMMAND_NAME = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+const PLANS = new Set<PluginPlanV1>(["free", "trial", "pro", "team", "enterprise"]);
+const ENTITLEMENT_STATES = new Set<PluginEntitlementStateV1>(["active", "grace", "missing", "expired"]);
 
 export function validatePluginManifestV1(manifest: AgentMemoryPluginManifestV1): void {
 	if (manifest.schemaVersion !== 1) throw new Error(`Unsupported plugin manifest schema for ${manifest.id}`);
@@ -154,11 +172,21 @@ export function validatePluginManifestV1(manifest: AgentMemoryPluginManifestV1):
 	if (!manifest.engine.trim()) throw new Error(`Plugin manifest ${manifest.id} has no engine range`);
 
 	const commands = new Set<string>();
+	const capabilities = new Set(manifest.capabilities ?? []);
+	if (capabilities.size !== (manifest.capabilities?.length ?? 0))
+		throw new Error(`Plugin manifest ${manifest.id} must declare unique capabilities`);
+	for (const capability of capabilities) {
+		if (!PLUGIN_ID.test(capability)) throw new Error(`Invalid capability '${capability}' in ${manifest.id}`);
+	}
 	for (const command of manifest.commands) {
 		if (!COMMAND_NAME.test(command.name)) throw new Error(`Invalid command '${command.name}' in ${manifest.id}`);
 		if (!command.description.trim())
 			throw new Error(`Command '${command.name}' in ${manifest.id} has no description`);
 		if (commands.has(command.name)) throw new Error(`Duplicate command '${command.name}' in ${manifest.id}`);
+		if (!capabilities.has(command.requiredCapability))
+			throw new Error(
+				`Command '${command.name}' in ${manifest.id} requires undeclared capability '${command.requiredCapability}'`,
+			);
 		commands.add(command.name);
 	}
 
@@ -166,6 +194,40 @@ export function validatePluginManifestV1(manifest: AgentMemoryPluginManifestV1):
 		if (!PLUGIN_ID.test(dependency)) throw new Error(`Invalid dependency '${dependency}' in ${manifest.id}`);
 		if (dependency === manifest.id) throw new Error(`Plugin ${manifest.id} cannot require itself`);
 	}
+}
+
+export function validatePluginEntitlementStatusV1(
+	entitlement: unknown,
+): asserts entitlement is PluginEntitlementStatusV1 {
+	if (!entitlement || typeof entitlement !== "object" || Array.isArray(entitlement))
+		throw new Error("Plugin entitlement must be an object");
+	const candidate = entitlement as Partial<PluginEntitlementStatusV1>;
+	if (candidate.plan !== null && !PLANS.has(candidate.plan as PluginPlanV1))
+		throw new Error("Plugin entitlement has an invalid plan");
+	if (!ENTITLEMENT_STATES.has(candidate.state as PluginEntitlementStateV1))
+		throw new Error("Plugin entitlement has an invalid state");
+	if (!Array.isArray(candidate.features) || candidate.features.some((feature) => typeof feature !== "string"))
+		throw new Error("Plugin entitlement features must be strings");
+	if (!candidate.capabilities || typeof candidate.capabilities !== "object" || Array.isArray(candidate.capabilities))
+		throw new Error("Plugin entitlement capabilities must be an object");
+	for (const [capability, grant] of Object.entries(candidate.capabilities)) {
+		if (!PLUGIN_ID.test(capability)) throw new Error(`Invalid entitlement capability: ${capability}`);
+		if (!grant || typeof grant !== "object" || Array.isArray(grant) || typeof grant.enabled !== "boolean")
+			throw new Error(`Capability ${capability} has an invalid grant`);
+		if (grant.quota) {
+			if (!Number.isInteger(grant.quota.limit) || grant.quota.limit <= 0)
+				throw new Error(`Capability ${capability} has an invalid quota limit`);
+			if (grant.quota.window !== "day" || grant.quota.scope !== "device")
+				throw new Error(`Capability ${capability} has an invalid quota policy`);
+		}
+	}
+}
+
+export function isPluginCapabilityEnabled(entitlement: PluginEntitlementStatusV1, capability: string): boolean {
+	return (
+		(entitlement.state === "active" || entitlement.state === "grace") &&
+		entitlement.capabilities?.[capability]?.enabled === true
+	);
 }
 
 export function validateBundleManifestV1(manifest: AgentMemoryBundleManifestV1): void {

--- a/src/plugin-host.ts
+++ b/src/plugin-host.ts
@@ -137,6 +137,7 @@ export interface AgentMemoryPluginHostV1 {
 	registerCommand(command: PluginCommandV1): void;
 	registerSessionStartHook(hook: PluginSessionStartHookV1): void;
 	getStateDirectory(): string;
+	getMemoryDirectory(): string;
 	getEntitlement(): Promise<PluginEntitlementStatusV1>;
 	redactSecrets(value: string): string;
 	writeMemory(request: PluginMemoryWriteV1): Promise<PluginMemoryWriteResultV1>;

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -1,0 +1,296 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { getMemoryDir, memoryWrite, redactSecrets, scheduleQmdUpdate } from "./core.js";
+import {
+	FilePluginInstallStore,
+	OFFICIAL_BUNDLE_ID,
+	type PluginBootstrapBackendV1,
+	PluginBootstrapFailure,
+	type PluginInstallReceiptV1,
+	type PluginInstallStoreV1,
+	type SignedPluginReleaseV1,
+} from "./plugin-bootstrap.js";
+import {
+	AGENT_MEMORY_PLUGIN_API_VERSION,
+	type AgentMemoryPluginBundleV1,
+	type AgentMemoryPluginHostV1,
+	type AgentMemoryPluginManifestV1,
+	isPluginCapabilityEnabled,
+	type PluginCommandContextV1,
+	type PluginCommandResultV1,
+	type PluginCommandV1,
+	type PluginEntitlementStatusV1,
+	type PluginMemoryCorrectionV1,
+	type PluginMemoryWriteV1,
+	type PluginSessionStartHookV1,
+	validateBundleManifestV1,
+	validatePluginEntitlementStatusV1,
+	validatePluginManifestV1,
+} from "./plugin-host.js";
+import { TemporaryPluginBackend } from "./plugin-service.js";
+
+interface RegisteredCommand {
+	command: PluginCommandV1;
+	pluginId: string;
+}
+
+export interface PluginRuntimeOptionsV1 {
+	coreVersion: string;
+	store?: PluginInstallStoreV1;
+	backend?: PluginBootstrapBackendV1;
+}
+
+function assertPermission(manifest: AgentMemoryPluginManifestV1, permission: string): void {
+	if (!manifest.permissions.includes(permission as never))
+		throw new PluginBootstrapFailure(
+			"plugin_permission_denied",
+			`Plugin ${manifest.id} did not declare permission ${permission}`,
+		);
+}
+
+function memoryResult(result: Awaited<ReturnType<typeof memoryWrite>>): {
+	ok: boolean;
+	path: string;
+	redacted: boolean;
+} {
+	if (result.isError)
+		throw new PluginBootstrapFailure("plugin_memory_write_failed", result.text.replace(/^Error:\s*/, ""));
+	return {
+		ok: true,
+		path: typeof result.details.path === "string" ? result.details.path : getMemoryDir(),
+		redacted: result.details.redacted === true,
+	};
+}
+
+async function importBundle(
+	directory: string,
+	receipt: Pick<PluginInstallReceiptV1, "entrypoint" | "bundleId" | "version">,
+): Promise<AgentMemoryPluginBundleV1> {
+	let component = path.resolve(directory);
+	const rootStat = fs.lstatSync(component);
+	if (!rootStat.isDirectory() || rootStat.isSymbolicLink())
+		throw new PluginBootstrapFailure("plugin_entrypoint_invalid", "The installed plugin directory is unsafe");
+	for (const part of receipt.entrypoint.split("/")) {
+		component = path.join(component, part);
+		const componentStat = fs.lstatSync(component);
+		if (componentStat.isSymbolicLink())
+			throw new PluginBootstrapFailure(
+				"plugin_entrypoint_invalid",
+				"The installed plugin path contains a symbolic link",
+			);
+	}
+	const entrypoint = path.resolve(directory, ...receipt.entrypoint.split("/"));
+	if (!entrypoint.startsWith(`${path.resolve(directory)}${path.sep}`))
+		throw new PluginBootstrapFailure(
+			"plugin_entrypoint_invalid",
+			"The installed plugin entrypoint escapes its bundle",
+		);
+	const stat = fs.lstatSync(entrypoint);
+	if (!stat.isFile() || stat.isSymbolicLink())
+		throw new PluginBootstrapFailure(
+			"plugin_entrypoint_invalid",
+			"The installed plugin entrypoint is not a regular file",
+		);
+	const imported = (await import(`${pathToFileURL(entrypoint).href}?v=${encodeURIComponent(receipt.version)}`)) as {
+		default?: unknown;
+	};
+	const bundle = imported.default as AgentMemoryPluginBundleV1 | undefined;
+	if (!bundle || bundle.apiVersion !== AGENT_MEMORY_PLUGIN_API_VERSION || !Array.isArray(bundle.plugins))
+		throw new PluginBootstrapFailure(
+			"plugin_bundle_invalid",
+			"The plugin entrypoint did not export a compatible bundle",
+		);
+	validateBundleManifestV1(bundle.manifest);
+	if (bundle.manifest.id !== receipt.bundleId || bundle.manifest.version !== receipt.version)
+		throw new PluginBootstrapFailure(
+			"plugin_bundle_invalid",
+			"The loaded plugin bundle identity does not match its receipt",
+		);
+	const pluginIds = new Set<string>();
+	for (const plugin of bundle.plugins) {
+		validatePluginManifestV1(plugin.manifest);
+		if (pluginIds.has(plugin.manifest.id))
+			throw new PluginBootstrapFailure("plugin_bundle_invalid", "The plugin bundle contains duplicate plugin ids");
+		pluginIds.add(plugin.manifest.id);
+	}
+	if (
+		pluginIds.size !== bundle.manifest.plugins.length ||
+		bundle.manifest.plugins.some((pluginId) => !pluginIds.has(pluginId))
+	)
+		throw new PluginBootstrapFailure("plugin_bundle_invalid", "The plugin bundle contents do not match its manifest");
+	return bundle;
+}
+
+export class InstalledPluginRuntimeV1 {
+	private readonly store: PluginInstallStoreV1;
+	private readonly backend: PluginBootstrapBackendV1;
+	private readonly commands = new Map<string, RegisteredCommand>();
+	private readonly hooks: PluginSessionStartHookV1[] = [];
+	private loaded = false;
+
+	constructor(private readonly options: PluginRuntimeOptionsV1) {
+		this.store = options.store ?? new FilePluginInstallStore();
+		this.backend = options.backend ?? new TemporaryPluginBackend({ root: this.store.root });
+	}
+
+	async load(): Promise<boolean> {
+		if (this.loaded) return true;
+		const receipt = this.store.readReceipt(OFFICIAL_BUNDLE_ID);
+		if (!receipt || !this.store.hasInstalledBundle(receipt)) return false;
+		await this.refreshEntitlement();
+		const directory = path.join(this.store.root, "bundles", receipt.bundleId, receipt.version);
+		const bundle = await importBundle(directory, receipt);
+		for (const plugin of bundle.plugins) {
+			const host = this.createHost(plugin.manifest);
+			await plugin.activate(host);
+			const health = await plugin.healthCheck(host);
+			if (!health.ok)
+				throw new PluginBootstrapFailure(
+					"plugin_health_check_failed",
+					health.message ?? `Plugin ${plugin.manifest.id} failed its health check`,
+				);
+		}
+		this.loaded = true;
+		return true;
+	}
+
+	async run(name: string, context: PluginCommandContextV1): Promise<PluginCommandResultV1 | null> {
+		if (!(await this.load())) return null;
+		const registered = this.commands.get(name);
+		if (!registered) return null;
+		const entitlement = await this.refreshEntitlement();
+		if (!isPluginCapabilityEnabled(entitlement, registered.command.requiredCapability))
+			return {
+				ok: false,
+				error: {
+					code: "plugin_capability_denied",
+					message: `Capability ${registered.command.requiredCapability} is not enabled for ${registered.pluginId}`,
+				},
+			};
+		return registered.command.run(context);
+	}
+
+	private createHost(manifest: AgentMemoryPluginManifestV1): AgentMemoryPluginHostV1 {
+		const descriptors = new Map(manifest.commands.map((command) => [command.name, command]));
+		const stateRoot = path.join(this.store.root, "state");
+		fs.mkdirSync(stateRoot, { recursive: true, mode: 0o700 });
+		const stateRootStat = fs.lstatSync(stateRoot);
+		if (!stateRootStat.isDirectory() || stateRootStat.isSymbolicLink())
+			throw new PluginBootstrapFailure("plugin_state_invalid", "The plugin state root is unsafe");
+		const stateDirectory = path.join(stateRoot, OFFICIAL_BUNDLE_ID);
+		if (!fs.existsSync(stateDirectory)) fs.mkdirSync(stateDirectory, { mode: 0o700 });
+		const stateDirectoryStat = fs.lstatSync(stateDirectory);
+		if (!stateDirectoryStat.isDirectory() || stateDirectoryStat.isSymbolicLink())
+			throw new PluginBootstrapFailure("plugin_state_invalid", "The plugin state directory is unsafe");
+		return {
+			apiVersion: AGENT_MEMORY_PLUGIN_API_VERSION,
+			coreVersion: this.options.coreVersion,
+			registerCommand: (command) => {
+				const descriptor = descriptors.get(command.name);
+				if (!descriptor || descriptor.requiredCapability !== command.requiredCapability)
+					throw new PluginBootstrapFailure(
+						"plugin_command_invalid",
+						`Plugin ${manifest.id} registered an undeclared command`,
+					);
+				const names = [command.name, ...(command.aliases ?? [])];
+				for (const name of names) {
+					if (this.commands.has(name))
+						throw new PluginBootstrapFailure(
+							"plugin_command_conflict",
+							`Plugin command ${name} is already registered`,
+						);
+				}
+				for (const name of names) this.commands.set(name, { command, pluginId: manifest.id });
+			},
+			registerSessionStartHook: (hook) => {
+				if (!(manifest.capabilities ?? []).includes(hook.requiredCapability))
+					throw new PluginBootstrapFailure(
+						"plugin_hook_invalid",
+						`Plugin ${manifest.id} registered a hook with an undeclared capability`,
+					);
+				this.hooks.push(hook);
+			},
+			getStateDirectory: () => stateDirectory,
+			getMemoryDirectory: () => {
+				assertPermission(manifest, "memory:read");
+				return getMemoryDir();
+			},
+			getEntitlement: async () => structuredClone(await this.refreshEntitlement()),
+			redactSecrets: (value) => redactSecrets(value).content,
+			writeMemory: async (request: PluginMemoryWriteV1) => {
+				assertPermission(manifest, "memory:write");
+				return memoryResult(await memoryWrite({ ...request, sessionId: `plugin-${manifest.id}` }));
+			},
+			correctMemory: async (request: PluginMemoryCorrectionV1) => {
+				assertPermission(manifest, "memory:correct");
+				const content = `Correction for ${request.artifactId}: ${request.content}${request.reason ? `\nReason: ${request.reason}` : ""}`;
+				return memoryResult(
+					await memoryWrite({
+						target: request.scope === "durable" ? "long_term" : "daily",
+						content,
+						sessionId: `plugin-${manifest.id}`,
+						sourceUri: request.sourceUri,
+					}),
+				);
+			},
+			scheduleSearchRefresh: () => {
+				assertPermission(manifest, "jobs:run");
+				scheduleQmdUpdate();
+			},
+		};
+	}
+
+	private async refreshEntitlement(): Promise<PluginEntitlementStatusV1> {
+		const entitlement = await this.backend.getLocalEntitlement();
+		validatePluginEntitlementStatusV1(entitlement);
+		return entitlement;
+	}
+}
+
+export function createInstalledBundleHealthCheck(
+	coreVersion: string,
+	backend: PluginBootstrapBackendV1,
+	storeRoot: string,
+): (directory: string, release: SignedPluginReleaseV1) => Promise<void> {
+	return async (directory, release) => {
+		const entitlement = await backend.getLocalEntitlement();
+		validatePluginEntitlementStatusV1(entitlement);
+		const receipt = {
+			bundleId: release.manifest.id,
+			version: release.manifest.version,
+			entrypoint: release.manifest.entrypoint,
+		};
+		const bundle = await importBundle(directory, receipt);
+		for (const plugin of bundle.plugins) {
+			const stateDirectory = path.join(storeRoot, "health", OFFICIAL_BUNDLE_ID);
+			const host: AgentMemoryPluginHostV1 = {
+				apiVersion: 1,
+				coreVersion,
+				registerCommand() {},
+				registerSessionStartHook() {},
+				getStateDirectory: () => stateDirectory,
+				getMemoryDirectory: () => {
+					assertPermission(plugin.manifest, "memory:read");
+					return getMemoryDir();
+				},
+				getEntitlement: async () => structuredClone(entitlement),
+				redactSecrets: (value) => redactSecrets(value).content,
+				async writeMemory() {
+					throw new PluginBootstrapFailure("plugin_health_check_invalid", "Health checks cannot write memory");
+				},
+				async correctMemory() {
+					throw new PluginBootstrapFailure("plugin_health_check_invalid", "Health checks cannot correct memory");
+				},
+				scheduleSearchRefresh() {},
+			};
+			const health = await plugin.healthCheck(host);
+			if (!health.ok)
+				throw new PluginBootstrapFailure(
+					"plugin_health_check_failed",
+					health.message ?? `Plugin ${plugin.manifest.id} failed its health check`,
+				);
+		}
+	};
+}

--- a/src/plugin-service.ts
+++ b/src/plugin-service.ts
@@ -1,0 +1,451 @@
+import { spawn } from "node:child_process";
+import { randomBytes, randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import * as path from "node:path";
+
+import {
+	getDefaultPluginInstallRoot,
+	type PluginAccessDecisionV1,
+	type PluginBootstrapBackendV1,
+	PluginBootstrapFailure,
+	type PluginNextActionV1,
+	type SignedPluginReleaseV1,
+} from "./plugin-bootstrap.js";
+import { type PluginEntitlementStatusV1, validatePluginEntitlementStatusV1 } from "./plugin-host.js";
+
+const API_ORIGIN = "https://api.agentmemory.paperpilot.me";
+const ARTIFACT_ORIGIN = "https://plugins.agentmemory.paperpilot.me";
+const ACTIVATION_FILE = "credentials/temporary-access.json";
+const REQUEST_TIMEOUT_MS = 30_000;
+const EMAIL_MAX_BYTES = 254;
+const FORM_MAX_BYTES = 2_048;
+const SERVICE_JSON_MAX_BYTES = 1024 * 1024;
+
+const MISSING_ENTITLEMENT: PluginEntitlementStatusV1 = {
+	plan: null,
+	state: "missing",
+	features: [],
+	capabilities: {},
+	reason: "Enter an email address to activate temporary unlimited local use",
+};
+
+const TEMPORARY_ENTITLEMENT: PluginEntitlementStatusV1 = {
+	plan: "pro",
+	state: "active",
+	features: ["session-intelligence", "web-console"],
+	capabilities: Object.fromEntries(
+		[
+			"session-index",
+			"session-worker",
+			"learning",
+			"retrieval-evaluation",
+			"operational-metrics",
+			"web-console",
+			"memory-explorer",
+		].map((capability) => [capability, { enabled: true }]),
+	),
+	reason: "Temporary email activation grants unlimited local use",
+};
+
+interface TemporaryActivationV1 {
+	schemaVersion: 1;
+	email: string;
+	activatedAt: string;
+}
+
+interface TemporaryPluginBackendOptions {
+	root?: string;
+	coreVersion?: string;
+	apiOrigin?: string;
+	artifactOrigin?: string;
+	fetch?: typeof globalThis.fetch;
+	openUrl?: (url: string) => boolean;
+	activate?: () => Promise<string>;
+}
+
+function cloneEntitlement(value: PluginEntitlementStatusV1): PluginEntitlementStatusV1 {
+	return structuredClone(value);
+}
+
+function isEmail(value: string): boolean {
+	return (
+		Buffer.byteLength(value, "utf-8") <= EMAIL_MAX_BYTES &&
+		[...value].every((character) => character.charCodeAt(0) >= 32 && character.charCodeAt(0) !== 127) &&
+		/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+	);
+}
+
+function securityHeaders(contentType: string): Record<string, string> {
+	return {
+		"Cache-Control": "no-store",
+		"Content-Security-Policy":
+			"default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'",
+		"Content-Type": contentType,
+		"Referrer-Policy": "same-origin",
+		"X-Content-Type-Options": "nosniff",
+	};
+}
+
+function activationPage(action: string, error?: string): string {
+	const errorHtml = error ? `<p class="error">${error}</p>` : "";
+	return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Activate AgentMemory Pro</title><style>body{font:16px system-ui;max-width:34rem;margin:10vh auto;padding:0 1.5rem;color:#18212b}form{display:grid;gap:1rem}input,button{font:inherit;padding:.8rem;border-radius:.5rem;border:1px solid #aab4bf}button{background:#18212b;color:#fff;cursor:pointer}.muted{color:#586574}.error{color:#a21d24}</style></head><body><h1>Activate AgentMemory Pro</h1><p>Enter an email address to enable temporary unlimited use on this device.</p>${errorHtml}<form method="post" action="${action}"><label>Email <input type="email" name="email" autocomplete="email" maxlength="254" required autofocus></label><button type="submit">Activate and return to terminal</button></form><p class="muted">The AgentMemory CLI sends your email plus core, bundle, platform, architecture, and release-channel metadata to the private activation service. The activation record never includes memory, session content, queries, repository paths, IP addresses, or user-agent strings, and expires after 365 days without activation.</p></body></html>`;
+}
+
+function completionPage(): string {
+	return '<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>AgentMemory activated</title></head><body><h1>Activation complete</h1><p>You can close this tab and return to the terminal.</p></body></html>';
+}
+
+function send(response: ServerResponse, status: number, body: string, contentType = "text/html; charset=utf-8"): void {
+	response.writeHead(status, securityHeaders(contentType));
+	response.end(body);
+}
+
+async function readBoundedBody(response: Response, maxBytes: number): Promise<Uint8Array> {
+	if (!response.body) return new Uint8Array();
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let size = 0;
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		size += value.byteLength;
+		if (size > maxBytes) {
+			await reader.cancel();
+			throw new PluginBootstrapFailure("service_response_too_large", "The plugin service response is too large");
+		}
+		chunks.push(value);
+	}
+	const output = new Uint8Array(size);
+	let offset = 0;
+	for (const chunk of chunks) {
+		output.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return output;
+}
+
+async function readJson(response: Response): Promise<unknown> {
+	try {
+		return JSON.parse(new TextDecoder().decode(await readBoundedBody(response, SERVICE_JSON_MAX_BYTES)));
+	} catch (error) {
+		if (error instanceof PluginBootstrapFailure) throw error;
+		throw new PluginBootstrapFailure("service_response_invalid", "The plugin service returned invalid JSON");
+	}
+}
+
+function readForm(request: IncomingMessage): Promise<URLSearchParams> {
+	return new Promise((resolve, reject) => {
+		let size = 0;
+		const chunks: Buffer[] = [];
+		request.on("data", (chunk: Buffer) => {
+			size += chunk.byteLength;
+			if (size > FORM_MAX_BYTES) {
+				reject(new Error("form too large"));
+				request.destroy();
+				return;
+			}
+			chunks.push(chunk);
+		});
+		request.on("end", () => resolve(new URLSearchParams(Buffer.concat(chunks).toString("utf-8"))));
+		request.on("error", reject);
+	});
+}
+
+function isSameOriginActivationPost(request: IncomingMessage, expectedHost: string, activationPath: string): boolean {
+	const expectedOrigin = `http://${expectedHost}`;
+	const origin = request.headers.origin;
+	const fetchSite = request.headers["sec-fetch-site"];
+	if (origin === "null") {
+		return (
+			fetchSite === "same-origin" &&
+			request.headers["sec-fetch-mode"] === "navigate" &&
+			request.headers["sec-fetch-dest"] === "document" &&
+			request.headers["sec-fetch-user"] === "?1"
+		);
+	}
+	if (origin !== undefined) return origin === expectedOrigin;
+
+	if (fetchSite !== undefined && fetchSite !== "same-origin") return false;
+
+	const referer = request.headers.referer;
+	if (referer !== undefined) {
+		try {
+			const parsed = new URL(referer);
+			return parsed.origin === expectedOrigin && parsed.pathname === activationPath;
+		} catch {
+			return false;
+		}
+	}
+
+	// Privacy-focused and older browsers may omit all three headers. The exact
+	// loopback Host plus the 192-bit, single-use path remains the CSRF capability.
+	return true;
+}
+
+export function openLoopbackUrl(url: string): boolean {
+	const parsed = new URL(url);
+	if (parsed.protocol !== "http:" || parsed.hostname !== "127.0.0.1") return false;
+	try {
+		const child =
+			process.platform === "darwin"
+				? spawn("open", [parsed.toString()], { detached: true, stdio: "ignore" })
+				: process.platform === "win32"
+					? spawn("explorer.exe", [parsed.toString()], { detached: true, stdio: "ignore" })
+					: spawn("xdg-open", [parsed.toString()], { detached: true, stdio: "ignore" });
+		child.unref();
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function collectTemporaryActivation(openUrl: (url: string) => boolean = openLoopbackUrl): Promise<string> {
+	const nonce = randomBytes(24).toString("hex");
+	const activationPath = `/activate/${nonce}`;
+	let expectedHost = "";
+	let settle: ((email: string) => void) | null = null;
+	let fail: ((error: Error) => void) | null = null;
+	const result = new Promise<string>((resolve, reject) => {
+		settle = resolve;
+		fail = reject;
+	});
+	const server = createServer(async (request, response) => {
+		if (request.headers.host !== expectedHost || request.url !== activationPath) {
+			send(response, 404, "Not found", "text/plain; charset=utf-8");
+			return;
+		}
+		if (request.method === "GET") {
+			send(response, 200, activationPage(activationPath));
+			return;
+		}
+		if (request.method !== "POST" || !isSameOriginActivationPost(request, expectedHost, activationPath)) {
+			send(response, 403, "Forbidden", "text/plain; charset=utf-8");
+			return;
+		}
+		try {
+			const email = (await readForm(request)).get("email")?.trim() ?? "";
+			if (!isEmail(email)) {
+				send(response, 400, activationPage(activationPath, "Enter a valid email address."));
+				return;
+			}
+			send(response, 200, completionPage());
+			settle?.(email);
+			settle = null;
+			server.close();
+		} catch {
+			send(response, 400, activationPage(activationPath, "The activation form could not be read."));
+		}
+	});
+	server.requestTimeout = 10_000;
+	server.headersTimeout = 10_000;
+	server.maxHeadersCount = 40;
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (!address || typeof address === "string")
+		throw new PluginBootstrapFailure("activation_failed", "Activation did not bind to loopback");
+	expectedHost = `127.0.0.1:${address.port}`;
+	const url = `http://${expectedHost}${activationPath}`;
+	console.log(`AgentMemory activation: ${url}`);
+	let opened = false;
+	try {
+		opened = openUrl(url);
+	} catch {
+		server.close();
+		throw new PluginBootstrapFailure("browser_unavailable", `Open this URL in a browser: ${url}`);
+	}
+	if (!opened) {
+		server.close();
+		throw new PluginBootstrapFailure("browser_unavailable", `Open this URL in a browser: ${url}`);
+	}
+	const timer = setTimeout(() => {
+		fail?.(new PluginBootstrapFailure("activation_timeout", "Temporary activation timed out", true));
+		server.close();
+	}, 5 * 60_000);
+	timer.unref();
+	try {
+		return await result;
+	} finally {
+		clearTimeout(timer);
+		server.close();
+	}
+}
+
+export class TemporaryPluginBackend implements PluginBootstrapBackendV1 {
+	private readonly root: string;
+	private readonly coreVersion: string;
+	private readonly apiOrigin: string;
+	private readonly artifactOrigin: string;
+	private readonly fetchImplementation: typeof globalThis.fetch;
+	private readonly openUrl: (url: string) => boolean;
+	private readonly activate: () => Promise<string>;
+
+	constructor(options: TemporaryPluginBackendOptions = {}) {
+		this.root = path.resolve(options.root ?? getDefaultPluginInstallRoot());
+		this.coreVersion = options.coreVersion ?? "0.0.0";
+		this.apiOrigin = options.apiOrigin ?? API_ORIGIN;
+		this.artifactOrigin = options.artifactOrigin ?? ARTIFACT_ORIGIN;
+		this.fetchImplementation = options.fetch ?? globalThis.fetch;
+		this.openUrl = options.openUrl ?? openLoopbackUrl;
+		this.activate = options.activate ?? (() => collectTemporaryActivation(this.openUrl));
+	}
+
+	async getLocalEntitlement(): Promise<PluginEntitlementStatusV1> {
+		return this.readActivation() ? cloneEntitlement(TEMPORARY_ENTITLEMENT) : cloneEntitlement(MISSING_ENTITLEMENT);
+	}
+
+	async resolveAccess(request: {
+		bundleId: string;
+		installedVersion?: string;
+		channel: string;
+		allowAuthentication: boolean;
+	}): Promise<PluginAccessDecisionV1> {
+		let activation = this.readActivation();
+		if (!activation) {
+			if (!request.allowAuthentication)
+				return {
+					kind: "auth_required",
+					entitlement: cloneEntitlement(MISSING_ENTITLEMENT),
+					nextAction: {
+						kind: "authenticate",
+						url: "https://jayzeng.github.io/agentmemory/",
+						message: "Run plugin install in an interactive terminal to enter an email address",
+					},
+				};
+			const email = await this.activate();
+			this.writeActivation(email);
+			activation = this.readActivation();
+		}
+		if (!activation)
+			throw new PluginBootstrapFailure("activation_failed", "The local activation record could not be loaded");
+		const response = await this.request(`${this.apiOrigin}/v1/plugin/access`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				schemaVersion: 1,
+				email: activation.email,
+				bundleId: request.bundleId,
+				installedVersion: request.installedVersion ?? null,
+				coreVersion: this.coreVersion,
+				channel: request.channel,
+				platform: process.platform,
+				architecture: process.arch,
+				consentVersion: "activation-v1",
+			}),
+		});
+		const value = (await readJson(response)) as { entitlement?: unknown; artifactGrant?: unknown };
+		validatePluginEntitlementStatusV1(value.entitlement);
+		if (typeof value.artifactGrant !== "string" || !value.artifactGrant)
+			throw new PluginBootstrapFailure("service_response_invalid", "The access response omitted its artifact grant");
+		return { kind: "granted", entitlement: value.entitlement, artifactGrant: value.artifactGrant };
+	}
+
+	async listReleases(request: {
+		bundleId: string;
+		channel: string;
+		artifactGrant: string;
+	}): Promise<SignedPluginReleaseV1[]> {
+		const response = await this.request(`${this.apiOrigin}/v1/plugin/releases`, {
+			headers: { Authorization: `Bearer ${request.artifactGrant}` },
+		});
+		const value = (await readJson(response)) as { releases?: unknown };
+		if (!Array.isArray(value.releases))
+			throw new PluginBootstrapFailure("service_response_invalid", "The release response is invalid");
+		return value.releases as SignedPluginReleaseV1[];
+	}
+
+	async downloadArtifact(request: { release: SignedPluginReleaseV1; artifactGrant: string }): Promise<Uint8Array> {
+		const response = await this.request(`${this.artifactOrigin}/v1/artifacts/download`, {
+			headers: { Authorization: `Bearer ${request.artifactGrant}` },
+		});
+		const declared = Number(response.headers.get("Content-Length"));
+		if (Number.isFinite(declared) && declared !== request.release.size)
+			throw new PluginBootstrapFailure("artifact_size_mismatch", "The artifact response size is invalid");
+		const artifact = await readBoundedBody(response, request.release.size);
+		if (artifact.byteLength !== request.release.size)
+			throw new PluginBootstrapFailure("artifact_size_mismatch", "The artifact response size is invalid");
+		return artifact;
+	}
+
+	async getManagementAction(): Promise<PluginNextActionV1 | null> {
+		return null;
+	}
+
+	private activationPath(): string {
+		return path.join(this.root, ...ACTIVATION_FILE.split("/"));
+	}
+
+	private readActivation(): TemporaryActivationV1 | null {
+		const activationPath = this.activationPath();
+		if (!fs.existsSync(activationPath)) return null;
+		try {
+			const rootStat = fs.lstatSync(this.root);
+			const credentialsStat = fs.lstatSync(path.dirname(activationPath));
+			if (
+				!rootStat.isDirectory() ||
+				rootStat.isSymbolicLink() ||
+				!credentialsStat.isDirectory() ||
+				credentialsStat.isSymbolicLink()
+			)
+				return null;
+			const stat = fs.lstatSync(activationPath);
+			if (!stat.isFile() || stat.isSymbolicLink() || (process.platform !== "win32" && (stat.mode & 0o077) !== 0))
+				return null;
+			const value = JSON.parse(fs.readFileSync(activationPath, "utf-8")) as TemporaryActivationV1;
+			return value.schemaVersion === 1 && isEmail(value.email) && Number.isFinite(Date.parse(value.activatedAt))
+				? value
+				: null;
+		} catch {
+			return null;
+		}
+	}
+
+	private writeActivation(email: string): void {
+		if (!isEmail(email)) throw new PluginBootstrapFailure("email_invalid", "Enter a valid email address");
+		const target = this.activationPath();
+		fs.mkdirSync(this.root, { recursive: true, mode: 0o700 });
+		const rootStat = fs.lstatSync(this.root);
+		if (!rootStat.isDirectory() || rootStat.isSymbolicLink())
+			throw new PluginBootstrapFailure("activation_path_invalid", "The plugin activation root is unsafe");
+		const directory = path.dirname(target);
+		if (!fs.existsSync(directory)) fs.mkdirSync(directory, { mode: 0o700 });
+		const directoryStat = fs.lstatSync(directory);
+		if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink())
+			throw new PluginBootstrapFailure("activation_path_invalid", "The plugin activation directory is unsafe");
+		const temporary = `${target}.tmp-${process.pid}-${randomUUID()}`;
+		fs.writeFileSync(
+			temporary,
+			`${JSON.stringify({ schemaVersion: 1, email, activatedAt: new Date().toISOString() }, null, 2)}\n`,
+			{ mode: 0o600, flag: "wx" },
+		);
+		fs.renameSync(temporary, target);
+	}
+
+	private async request(url: string, init: RequestInit = {}): Promise<Response> {
+		let response: Response;
+		try {
+			response = await this.fetchImplementation(url, {
+				...init,
+				signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+				headers: { Accept: "application/json", ...init.headers },
+			});
+		} catch {
+			throw new PluginBootstrapFailure("service_unavailable", "The AgentMemory plugin service is unavailable", true);
+		}
+		if (!response.ok) {
+			let message = `The AgentMemory plugin service returned HTTP ${response.status}`;
+			try {
+				const value = (await readJson(response)) as { error?: { message?: unknown } };
+				if (typeof value.error?.message === "string") message = value.error.message;
+			} catch (error) {
+				if (error instanceof PluginBootstrapFailure && error.code === "service_response_too_large") throw error;
+				// Keep the bounded generic response.
+			}
+			throw new PluginBootstrapFailure("service_request_failed", message, response.status >= 500);
+		}
+		return response;
+	}
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -612,7 +612,24 @@ describe("CLI subprocess", () => {
 		expect(stdout).not.toContain(pluginDir);
 	});
 
-	test("plugin install fails closed when the production service is not configured", () => {
+	test("plugin discovery explains Pro value and the installation next step", () => {
+		const pluginDir = path.join(tmpDir, "plugin-install");
+		const result = Bun.spawnSync(["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "plugin"], {
+			env: { ...process.env, AGENT_MEMORY_PLUGIN_DIR: pluginDir },
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		expect(result.exitCode).toBe(0);
+		const stdout = result.stdout.toString();
+		expect(stdout).toContain("AgentMemory Pro includes:");
+		expect(stdout).toContain("Session Intelligence");
+		expect(stdout).toContain("Guided Learning");
+		expect(stdout).toContain("Local Web Console");
+		expect(stdout).toContain("Your session content stays on this device.");
+		expect(stdout).toContain("agent-memory plugin install");
+	});
+
+	test("non-interactive plugin install requires temporary email activation without touching disk", () => {
 		const pluginDir = path.join(tmpDir, "plugin-install");
 		const result = Bun.spawnSync(
 			["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "plugin", "install", "--json"],
@@ -625,8 +642,9 @@ describe("CLI subprocess", () => {
 		expect(result.exitCode).toBe(1);
 		const out = JSON.parse(result.stdout.toString());
 		expect(out.ok).toBe(false);
-		expect(out.result).toBe("unavailable");
-		expect(out.error.code).toBe("service_not_configured");
+		expect(out.result).toBe("auth_required");
+		expect(out.error.code).toBe("auth_required");
+		expect(out.nextAction.url).toBe("https://jayzeng.github.io/agentmemory/");
 		expect(fs.existsSync(pluginDir)).toBe(false);
 	});
 
@@ -686,7 +704,7 @@ describe("CLI subprocess", () => {
 		expect(out.error.code).toBe("channel_invalid");
 	});
 
-	test("plugin help documents that commercial networking is not configured", () => {
+	test("plugin help documents temporary activation", () => {
 		const result = Bun.spawnSync(["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "plugin", "--help"], {
 			stdout: "pipe",
 			stderr: "pipe",
@@ -694,7 +712,7 @@ describe("CLI subprocess", () => {
 		expect(result.exitCode).toBe(0);
 		const out = result.stdout.toString();
 		expect(out).toContain("agent-memory plugin install");
-		expect(out).toContain("unavailable until a production commercial service");
+		expect(out).toContain("temporary email activation");
 	});
 
 	test("unknown command exits with error", async () => {
@@ -716,9 +734,14 @@ describe("CLI subprocess", () => {
 	});
 
 	test("status --json includes embedMode field", async () => {
+		const pluginDir = path.join(tmpDir, "plugin-install");
 		const result = Bun.spawnSync(
 			["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "status", "--dir", tmpDir, "--json"],
-			{ stdout: "pipe", stderr: "pipe" },
+			{
+				env: { ...process.env, AGENT_MEMORY_PLUGIN_DIR: pluginDir },
+				stdout: "pipe",
+				stderr: "pipe",
+			},
 		);
 		expect(result.exitCode).toBe(0);
 		const out = JSON.parse(result.stdout.toString());
@@ -1111,8 +1134,18 @@ describe("npm package portability", () => {
 			}>;
 			const packedPaths = pack.files.map((file) => file.path);
 			expect(packedPaths).toContain("dist/cli.js");
+			expect(packedPaths).toContain("LICENSE");
+			expect(packedPaths).toContain("docs/official-plugin-bootstrap.md");
 			expect(packedPaths).not.toContain("dist/agent-memory");
 			expect(packedPaths).not.toContain("dist/agent-memory.exe");
+			expect(packedPaths).not.toContain("issues.md");
+			expect(packedPaths).not.toContain("progress.md");
+			expect(
+				packedPaths.some((packedPath) =>
+					["plugins/", "services/", "artifacts/", "LICENSES/"].some((prefix) => packedPath.startsWith(prefix)),
+				),
+			).toBe(false);
+			expect(packedPaths.some((packedPath) => packedPath.endsWith(".map"))).toBe(false);
 			expect(pack.unpackedSize).toBeLessThan(2_000_000);
 
 			const prefix = path.join(tempDir, "prefix");

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -91,6 +91,8 @@ import {
 	validatePluginEntitlementStatusV1,
 	validatePluginManifestV1,
 } from "../src/plugin-host.js";
+import { InstalledPluginRuntimeV1 } from "../src/plugin-runtime.js";
+import { collectTemporaryActivation, TemporaryPluginBackend } from "../src/plugin-service.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -2236,5 +2238,225 @@ describe("official plugin bootstrap", () => {
 		expect(result.result).toBe("uninstalled");
 		expect(fs.existsSync(userData)).toBe(true);
 		expect(new FilePluginInstallStore(installRoot).readReceipt(OFFICIAL_BUNDLE_ID)).toBeNull();
+	});
+});
+
+describe("temporary plugin activation and runtime", () => {
+	test("closes activation when the browser launcher throws", async () => {
+		await expect(
+			collectTemporaryActivation(() => {
+				throw new Error("launcher failed");
+			}),
+		).rejects.toMatchObject({ code: "browser_unavailable" });
+	});
+
+	test("collects an email when a same-origin browser omits Origin but sends Fetch Metadata and Referer", async () => {
+		let page = "";
+		const email = await collectTemporaryActivation((url) => {
+			void (async () => {
+				const loaded = await fetch(url);
+				page = await loaded.text();
+				const submitted = await fetch(url, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded",
+						Referer: url,
+						"Sec-Fetch-Site": "same-origin",
+					},
+					body: new URLSearchParams({ email: "beta@example.invalid" }),
+				});
+				expect(submitted.status).toBe(200);
+			})();
+			return true;
+		});
+		expect(page).toContain("Activate AgentMemory Pro");
+		expect(page).toContain(
+			"sends your email plus core, bundle, platform, architecture, and release-channel metadata",
+		);
+		expect(page).toContain("never includes memory, session content, queries, repository paths, IP addresses");
+		expect(page).toContain("expires after 365 days without activation");
+		expect(email).toBe("beta@example.invalid");
+	});
+
+	test("accepts Chromium's opaque Origin only for a user-initiated same-origin document navigation", async () => {
+		let referrerPolicy = "";
+		const email = await collectTemporaryActivation((url) => {
+			void (async () => {
+				const loaded = await fetch(url);
+				referrerPolicy = loaded.headers.get("Referrer-Policy") ?? "";
+				const submitted = await fetch(url, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded",
+						Origin: "null",
+						"Sec-Fetch-Dest": "document",
+						"Sec-Fetch-Mode": "navigate",
+						"Sec-Fetch-Site": "same-origin",
+						"Sec-Fetch-User": "?1",
+					},
+					body: new URLSearchParams({ email: "chromium@example.invalid" }),
+				});
+				expect(submitted.status).toBe(200);
+			})();
+			return true;
+		});
+		expect(referrerPolicy).toBe("same-origin");
+		expect(email).toBe("chromium@example.invalid");
+	});
+
+	test("rejects a cross-origin activation POST without consuming the nonce", async () => {
+		const email = await collectTemporaryActivation((url) => {
+			void (async () => {
+				const rejectedOpaqueOrigin = await fetch(url, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded",
+						Origin: "null",
+						"Sec-Fetch-Dest": "document",
+						"Sec-Fetch-Mode": "navigate",
+						"Sec-Fetch-Site": "cross-site",
+						"Sec-Fetch-User": "?1",
+					},
+					body: new URLSearchParams({ email: "attacker@example.invalid" }),
+				});
+				expect(rejectedOpaqueOrigin.status).toBe(403);
+				const rejected = await fetch(url, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded",
+						Origin: "https://malicious.example",
+						"Sec-Fetch-Site": "cross-site",
+					},
+					body: new URLSearchParams({ email: "attacker@example.invalid" }),
+				});
+				expect(rejected.status).toBe(403);
+				const submitted = await fetch(url, {
+					method: "POST",
+					headers: { "Content-Type": "application/x-www-form-urlencoded" },
+					body: new URLSearchParams({ email: "beta@example.invalid" }),
+				});
+				expect(submitted.status).toBe(200);
+			})();
+			return true;
+		});
+		expect(email).toBe("beta@example.invalid");
+	});
+
+	test("persists temporary activation locally and returns unlimited access", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-memory-activation-"));
+		try {
+			const entitlement: PluginEntitlementStatusV1 = {
+				plan: "pro",
+				state: "active",
+				features: ["session-intelligence", "web-console"],
+				capabilities: { learning: { enabled: true }, "web-console": { enabled: true } },
+			};
+			let activations = 0;
+			let accessRequest: Record<string, unknown> | null = null;
+			const backend = new TemporaryPluginBackend({
+				root,
+				coreVersion: "0.4.14",
+				activate: async () => {
+					activations++;
+					return "beta@example.invalid";
+				},
+				fetch: (async (_input, init) => {
+					accessRequest = JSON.parse(String(init?.body)) as Record<string, unknown>;
+					return new Response(JSON.stringify({ entitlement, artifactGrant: "grant" }), {
+						headers: { "Content-Type": "application/json" },
+					});
+				}) as typeof fetch,
+			});
+			const access = await backend.resolveAccess({
+				bundleId: OFFICIAL_BUNDLE_ID,
+				channel: "stable",
+				allowAuthentication: true,
+			});
+			expect(access.kind).toBe("granted");
+			expect(activations).toBe(1);
+			expect((await backend.getLocalEntitlement()).capabilities.learning.enabled).toBe(true);
+			const record = path.join(root, "credentials", "temporary-access.json");
+			expect(fs.statSync(record).mode & 0o777).toBe(0o600);
+			expect(fs.readFileSync(record, "utf-8")).toContain("beta@example.invalid");
+			expect(accessRequest).toMatchObject({
+				schemaVersion: 1,
+				email: "beta@example.invalid",
+				bundleId: OFFICIAL_BUNDLE_ID,
+				installedVersion: null,
+				coreVersion: "0.4.14",
+				channel: "stable",
+				platform: process.platform,
+				architecture: process.arch,
+				consentVersion: "activation-v1",
+			});
+			if (process.platform !== "win32") {
+				fs.chmodSync(record, 0o644);
+				expect((await backend.getLocalEntitlement()).state).toBe("missing");
+				fs.chmodSync(record, 0o600);
+			}
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects oversized plugin-service error responses", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-memory-service-error-"));
+		try {
+			const backend = new TemporaryPluginBackend({
+				root,
+				activate: async () => "beta@example.invalid",
+				fetch: (async () =>
+					new Response("x".repeat(1024 * 1024 + 1), {
+						status: 503,
+						headers: { "Content-Type": "application/json" },
+					})) as typeof fetch,
+			});
+			await expect(
+				backend.resolveAccess({
+					bundleId: OFFICIAL_BUNDLE_ID,
+					channel: "stable",
+					allowAuthentication: true,
+				}),
+			).rejects.toMatchObject({ code: "service_response_too_large" });
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("loads an installed bundle and enforces capability checks on every command", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-memory-runtime-"));
+		try {
+			const manifest: AgentMemoryBundleManifestV1 = {
+				...testBundleManifest("1.0.0"),
+				plugins: ["agentmemory.runtime-test"],
+			};
+			const source = Buffer.from(
+				`const manifest=${JSON.stringify(manifest)};export default {apiVersion:1,manifest,plugins:[{manifest:{schemaVersion:1,id:"agentmemory.runtime-test",name:"Runtime Test",version:"1.0.0",description:"Runtime test",engine:">=0.4.0",entitlement:"commercial",commands:[{name:"runtime-ping",description:"Ping",requiredCapability:"learning"}],permissions:[],capabilities:["learning"]},async activate(host){host.registerCommand({name:"runtime-ping",description:"Ping",requiredCapability:"learning",async run(context){return {ok:true,data:{args:context.args}}}})},async healthCheck(){return {ok:true}}}]};\n`,
+			);
+			const artifact = encodePluginPackage({
+				schemaVersion: 1,
+				manifest,
+				files: [{ path: manifest.entrypoint, sha256: sha256(source), contentBase64: source.toString("base64") }],
+			});
+			const release: SignedPluginReleaseV1 = {
+				schemaVersion: 1,
+				manifest,
+				platform: "any",
+				architecture: "any",
+				packageSha256: sha256(artifact),
+				size: artifact.byteLength,
+				signature: { algorithm: "ed25519", keyId: "test", value: Buffer.alloc(64).toString("base64") },
+			};
+			const store = new FilePluginInstallStore(root);
+			await store.install(artifact, release);
+			const backend = new FakePluginBackend();
+			const runtime = new InstalledPluginRuntimeV1({ coreVersion: "0.4.13", store, backend });
+			const context = { args: ["one"], flags: {}, signal: new AbortController().signal };
+			expect(await runtime.run("runtime-ping", context)).toEqual({ ok: true, data: { args: ["one"] } });
+			backend.entitlement.capabilities.learning.enabled = false;
+			expect((await runtime.run("runtime-ping", context))?.error?.code).toBe("plugin_capability_denied");
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
 	});
 });

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -83,9 +83,13 @@ import {
 } from "../src/plugin-bootstrap.js";
 import {
 	type AgentMemoryBundleManifestV1,
+	type AgentMemoryPluginManifestV1,
+	isPluginCapabilityEnabled,
 	isSafeBundlePath,
 	type PluginEntitlementStatusV1,
 	validateBundleManifestV1,
+	validatePluginEntitlementStatusV1,
+	validatePluginManifestV1,
 } from "../src/plugin-host.js";
 
 // ---------------------------------------------------------------------------
@@ -1905,6 +1909,10 @@ const ACTIVE_PLUGIN_ENTITLEMENT: PluginEntitlementStatusV1 = {
 	plan: "pro",
 	state: "active",
 	features: ["session-intelligence", "web-console"],
+	capabilities: {
+		learning: { enabled: true, quota: { limit: 3, window: "day", scope: "device" } },
+		"web-console": { enabled: true },
+	},
 	expiresAt: "2027-08-16T00:00:00Z",
 	offlineUntil: "2026-09-15T00:00:00Z",
 };
@@ -1993,6 +2001,56 @@ function signedTestRelease(
 }
 
 describe("official plugin host contract", () => {
+	test("keeps commercial plans separate from locally derived entitlement state", () => {
+		const freeEntitlement: PluginEntitlementStatusV1 = {
+			plan: "free",
+			state: "active",
+			features: ["session-intelligence"],
+			capabilities: {
+				learning: { enabled: true, quota: { limit: 3, window: "day", scope: "device" } },
+				"web-console": { enabled: false },
+			},
+		};
+
+		expect(isPluginCapabilityEnabled(freeEntitlement, "learning")).toBe(true);
+		expect(isPluginCapabilityEnabled(freeEntitlement, "web-console")).toBe(false);
+		expect(isPluginCapabilityEnabled({ ...freeEntitlement, state: "expired" }, "learning")).toBe(false);
+		expect(() => validatePluginEntitlementStatusV1(freeEntitlement)).not.toThrow();
+		expect(() =>
+			validatePluginEntitlementStatusV1({
+				...freeEntitlement,
+				capabilities: { learning: { enabled: true, quota: { limit: 0, window: "day", scope: "device" } } },
+			}),
+		).toThrow("invalid quota limit");
+		expect(() => validatePluginEntitlementStatusV1({ ...freeEntitlement, capabilities: undefined })).toThrow(
+			"capabilities must be an object",
+		);
+	});
+
+	test("requires command capability guards to reference declared capabilities", () => {
+		const manifest: AgentMemoryPluginManifestV1 = {
+			schemaVersion: 1,
+			id: "agentmemory.session-intelligence",
+			name: "Session Intelligence",
+			version: "1.0.0",
+			description: "Session learning",
+			engine: ">=0.1.0",
+			entitlement: "commercial",
+			commands: [{ name: "learn", description: "Learn", requiredCapability: "learning" }],
+			permissions: ["sessions:read"],
+			capabilities: ["learning"],
+		};
+
+		expect(() => validatePluginManifestV1(manifest)).not.toThrow();
+		expect(() =>
+			validatePluginManifestV1({
+				...manifest,
+				commands: [{ name: "learn", description: "Learn", requiredCapability: "undeclared" }],
+			}),
+		).toThrow("requires undeclared capability");
+		expect(() => validatePluginManifestV1({ ...manifest, commands: [] })).not.toThrow();
+	});
+
 	test("validates bundle identity, entrypoint, and plugin IDs", () => {
 		expect(() => validateBundleManifestV1(testBundleManifest("1.0.0"))).not.toThrow();
 		expect(isSafeBundlePath("bundle/index.js")).toBe(true);
@@ -2115,7 +2173,7 @@ describe("official plugin bootstrap", () => {
 	});
 
 	test("returns an authentication action without changing disk", async () => {
-		backend.entitlement = { plan: null, state: "missing", features: [] };
+		backend.entitlement = { plan: null, state: "missing", features: [], capabilities: {} };
 		backend.decision = {
 			kind: "auth_required",
 			entitlement: structuredClone(backend.entitlement),


### PR DESCRIPTION
## Summary

- ship the MIT-licensed public plugin host, signed bootstrap, temporary beta activation client, and installed-bundle runtime
- keep optional proprietary implementations outside the public npm artifact
- release `myagentmemory` 0.4.14 through npm trusted publishing with pinned toolchains and provenance
- expose the permission-checked core memory directory required by the private Web Console

## Verification

- `bun test test/unit.test.ts` (177 pass)
- `bun test test/cli.test.ts` (58 pass)
- `bun run lint`
- `bun run build`
- `bun run test:eval` (6 pass)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm pack --dry-run --json` (38 files; no private plugin/service/assets, source maps, local notes, or key material)
- `bun src/cli.ts recall "what is our recent conversation"` (8 recent hits; query not echoed)

## Storage and qmd

- No on-disk memory format changes.
- No qmd schema, collection, or retrieval-engine changes.
- Temporary activation state is isolated under the plugin install root, not the Markdown memory directory.
