### PR TITLE
fix: pin npm release client

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
-      - run: npm install --global npm@12.0.2
+      - run: npm install --global npm@11.6.2
       - run: npm --version
       - run: npm ci
       - name: Verify tag matches package.json version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Sent an explicit, bounded Pro activation record to the private control plane with transparent browser disclosure; the payload excludes memory, sessions, queries, paths, IP addresses, and user-agent strings
 
 ### Fixed
+- Pin the npm release client to the tested 11.6.2 toolchain so package-portability verification remains stable before trusted publication
 - Expose the real core memory directory to permission-checked first-party plugins so local interfaces do not confuse plugin operational state with user memory
 - Accepted same-origin loopback activation forms from browsers that omit `Origin` or serialize it as `null`, while preserving nonce/Host validation and rejecting cross-origin requests
 - Reload local entitlement state before every installed-plugin command and bound error responses from the plugin service


### PR DESCRIPTION
## Summary
- pin the release workflow to npm 11.6.2, the tested trusted-publishing client
- keep package-portability verification stable before publication
- document the release-toolchain fix in 0.4.14

## Verification
- `bun test test/unit.test.ts`
- `bun test test/cli.test.ts`
- `bun run lint`
- `bun run build`

## On-disk memory and qmd
- No memory-file format, location, or migration changes
- No qmd configuration or index changes

The original v0.4.14 publish run stopped before `npm publish`; the npm version is not present in the registry.