### PR TITLE
fix: preserve CLI during npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,3 +50,5 @@ jobs:
       - run: npm run test:eval
       - run: npm audit --audit-level=moderate
       - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ All notable changes to this project will be documented in this file.
 - Sent an explicit, bounded Pro activation record to the private control plane with transparent browser disclosure; the payload excludes memory, sessions, queries, paths, IP addresses, and user-agent strings
 
 ### Fixed
-- Pin the npm release client to the tested 11.6.2 toolchain so package-portability verification remains stable before trusted publication
+- Pin the npm release client to the tested 11.6.2 toolchain so package-portability verification remains stable before publication
+- Normalize the CLI executable path so npm preserves the `agent-memory` binary during publication
 - Expose the real core memory directory to permission-checked first-party plugins so local interfaces do not confuse plugin operational state with user memory
 - Accepted same-origin loopback activation forms from browsers that omit `Origin` or serialize it as `null`, while preserving nonce/Host validation and rejecting cross-origin requests
 - Reload local entitlement state before every installed-plugin command and bound error responses from the plugin service

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		}
 	},
 	"bin": {
-		"agent-memory": "./dist/cli.js"
+		"agent-memory": "dist/cli.js"
 	},
 	"type": "module",
 	"engines": {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1115,7 +1115,7 @@ describe("npm package portability", () => {
 			version: string;
 			bin: Record<string, string>;
 		};
-		expect(packageJson.bin["agent-memory"]).toBe("./dist/cli.js");
+		expect(packageJson.bin["agent-memory"]).toBe("dist/cli.js");
 
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-memory-npm-package-"));
 		try {


### PR DESCRIPTION
## Summary
- normalize the published `agent-memory` binary path so npm does not remove it
- update package-portability coverage for the normalized manifest
- scope the existing `NPM_TOKEN` secret to the final publish step after npm Trusted Publishing rejected the unconfigured OIDC identity

## Verification
- `npm pkg fix --dry-run --json`
- `bun test test/unit.test.ts`
- `bun test test/cli.test.ts`
- `bun run lint`
- `bun run build`

## On-disk memory and qmd
- No memory-file format, location, or migration changes
- No qmd configuration or index changes

The v0.4.14 package remains absent from npm. The preceding release run passed lint, build, unit, CLI, eval, and audit before npm rejected the unconfigured Trusted Publisher identity.