### PR TITLE
chore: release 0.4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.16] - 2026-08-17
+
+### Changed
+
 - Redesigned the loopback activation and completion pages with a focused responsive card layout, clearer activation copy, extension-safe email input spacing, accessible focus/error states, and progressive privacy disclosure.
 
 ## [0.4.15] - 2026-08-17

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "myagentmemory",
-	"version": "0.4.14",
+	"version": "0.4.16",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "myagentmemory",
-			"version": "0.4.14",
+			"version": "0.4.16",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "myagentmemory",
-	"version": "0.4.15",
+	"version": "0.4.16",
 	"description": "agentmemory (agent-memory) is persistent memory for coding agents (Claude Code, OpenAI Codex, Cursor, Agent) with qmd-powered semantic search across daily logs, long-term memory, and scratchpad",
 	"main": "./dist/core.js",
 	"types": "./dist/core.d.ts",


### PR DESCRIPTION
## Summary

- bump the public core package to 0.4.16
- publish the redesigned activation and completion flow
- align package-lock metadata with the release version

## Verification

- bun test test/unit.test.ts
- bun test test/cli.test.ts
- bun run lint
- bun run build
- npm run test:eval
- npm pack --dry-run

## Storage impact

No on-disk memory format or qmd behavior changes.