### PR TITLE
test: isolate Pro install from production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Isolated the anonymous Pro-install CLI test from the live production service so a healthy preview deployment cannot make the deterministic Core suite fail.
+
 ## [0.4.17] - 2026-08-17
 
 ### Added

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -634,7 +634,15 @@ describe("CLI subprocess", () => {
 	test("non-interactive plugin install attempts anonymous preview access without requiring identity", () => {
 		const pluginDir = path.join(tmpDir, "plugin-install");
 		const result = Bun.spawnSync(
-			["bun", "run", path.join(__dirname, "..", "src", "cli.ts"), "plugin", "install", "--json"],
+			[
+				"bun",
+				"--preload",
+				path.join(__dirname, "fixtures", "plugin-service-unavailable.ts"),
+				path.join(__dirname, "..", "src", "cli.ts"),
+				"plugin",
+				"install",
+				"--json",
+			],
 			{
 				env: { ...process.env, AGENT_MEMORY_PLUGIN_DIR: pluginDir },
 				stdout: "pipe",

--- a/test/fixtures/plugin-service-unavailable.ts
+++ b/test/fixtures/plugin-service-unavailable.ts
@@ -1,0 +1,11 @@
+globalThis.fetch = async () =>
+	new Response(
+		JSON.stringify({
+			schemaVersion: 1,
+			error: { code: "service_unavailable", message: "Test plugin service is unavailable" },
+		}),
+		{
+			status: 503,
+			headers: { "content-type": "application/json" },
+		},
+	);


### PR DESCRIPTION
## Summary

- preload a deterministic 503 plugin-service response for the anonymous install CLI test
- stop the Core suite from depending on whether the production Pro preview is deployed
- retain coverage that non-interactive install requires no identity and returns a structured retryable failure

## Verification

- `bun test test/unit.test.ts`
- `bun test test/cli.test.ts`
- `bun run lint`
- `bun run build`
- `AGENT_MEMORY_CORE_CHECKOUT=/Users/jay/designland/aimemory/agentmemory bun run validate:local` from the private Pro workspace

## Data and qmd changes

None. No memory-file format or qmd behavior changes.