### PR TITLE
chore: update Homebrew formula for v0.5.1

### DIFF
--- a/Formula/agent-memory.rb
+++ b/Formula/agent-memory.rb
@@ -1,9 +1,9 @@
 class AgentMemory < Formula
   desc "agentmemory CLI: persistent memory for coding agents with qmd semantic search"
   homepage "https://github.com/jayzeng/agentmemory"
-  url "https://github.com/jayzeng/agentmemory/archive/refs/tags/v0.5.0.tar.gz"
-  sha256 "76e840b923a955d6f4be40dec481ec2187757f3414a84590d4b8570a69ac5eba"
-  version "0.5.0"
+  url "https://github.com/jayzeng/agentmemory/archive/refs/tags/v0.5.1.tar.gz"
+  sha256 "dc329f1ab9067172b703adb2aa0d8396cea910d3c7c7d9ef31e03b4724ce2d35"
+  version "0.5.1"
   license "MIT"
 
   depends_on "bun" => :build


### PR DESCRIPTION
Auto-generated by the Update Homebrew Formula workflow (which could not open this PR itself: "GitHub Actions is not permitted to create or approve pull requests"). Opening manually on its behalf.

- Bumps `Formula/agent-memory.rb` to release tag `v0.5.1`.
- Records the GitHub source archive sha256, independently verified via two separate downloads: `dc329f1ab9067172b703adb2aa0d8396cea910d3c7c7d9ef31e03b4724ce2d35`.