### PR TITLE
chore: update Homebrew formula for v0.5.5

### DIFF
--- a/Formula/agent-memory.rb
+++ b/Formula/agent-memory.rb
@@ -1,9 +1,9 @@
 class AgentMemory < Formula
   desc "agentmemory CLI: persistent memory for coding agents with qmd semantic search"
   homepage "https://github.com/jayzeng/agentmemory"
-  url "https://github.com/jayzeng/agentmemory/archive/refs/tags/v0.5.4.tar.gz"
-  sha256 "29b16da3b857d644b427c5ae39b61d336189d8027aa69eb08cda742c814e92f1"
-  version "0.5.4"
+  url "https://github.com/jayzeng/agentmemory/archive/refs/tags/v0.5.5.tar.gz"
+  sha256 "ba85f8a844e4540f2d54c705a5b2c4fc39a63ad203068ced8dcad7ec08a53667"
+  version "0.5.5"
   license "MIT"
 
   depends_on "bun" => :build


### PR DESCRIPTION
Auto-generated by the Update Homebrew Formula workflow (workflow_run off the v0.5.5 npm publish), which pushed this branch but couldn't open the PR itself (GitHub Actions is not permitted to create or approve pull requests in this repo). Same pattern as #22 for v0.5.4.