### PR TITLE
feat: check uncaptured work at stop hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ The npm package installs a platform-neutral Node.js executable. The optional Hom
 
 Pi doesn't use SKILL.md or a JSON hook config — its extensibility model is a registered native extension. So instead of writing a skill file, `agent-memory setup`/`install-hooks` detects `pi` on your `PATH` and installs [`pi-memory`](https://github.com/jayzeng/pi-memory) for you, via `pi install npm:pi-memory` — same author, same memory-file conventions, native pi tools (`memory_write`, `memory_read`, `scratchpad`, `memory_search`). It's prompted for like any other detected agent and auto-applied under `--yes`; run `agent-memory install-hooks --only pi` to target just pi, or check `agent-memory doctor` for its status.
 
+### Capture checks
+
+The Claude Code Stop hook checks a bounded local transcript tail for explicit English “remember this/that/to” requests and successful `Edit`, `Write`, or `MultiEdit` calls. It can remind the agent on the first turn when no subsequent successful AgentMemory write is visible. Unchanged uncaptured work is retried every six eligible Stop events; successful recognized writes clear the check. Ordinary conversation stays quiet. Without a usable transcript, the hook falls back to a reminder every six eligible Stop events.
+
+This is a capture check, not automatic extraction or proof that a note contains every important fact. It recognizes direct `agent-memory write`/`save` shell calls and `memory_write` tools with successful write receipts; shell wrappers and other editing tools rely on the agent's own checkpoint discipline. Only signal hashes and counters are saved in hook state. Codex, Cursor, and Agent receive checkpoint guidance through their skills; they do not gain a Claude Stop hook.
+
 ### Optional: Enable search with qmd
 
 When qmd is installed, the collection is automatically set up via `agent-memory setup` (or `init`).

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
 		"scripts/install-skills.sh",
 		"scripts/install-skills.ps1",
 		"scripts/postinstall.cjs",
+		"dist/capture-check.d.ts",
+		"dist/capture-check.js",
 		"dist/cli.d.ts",
 		"dist/cli.js",
 		"dist/core.d.ts",

--- a/skills/agent/SKILL.md
+++ b/skills/agent/SKILL.md
@@ -32,6 +32,12 @@ agent-memory search --query "<topic>" --mode keyword
 2. Mark completed scratchpad items as done; add new follow-ups
 3. Only write to long-term memory if you discovered a **durable fact** that doesn't already exist there
 
+## Capture at meaningful checkpoints
+
+When the user explicitly asks you to remember something, save it in that turn. After a decision is settled, a correction is accepted, or a fix is verified, record the useful outcome before reporting completion; do not wait for the session to end. Respect the user's memory and privacy preferences.
+
+Check whether that outcome was already saved. A write attempt is not a completed capture: verify the tool succeeded, and report a failed write rather than claiming you remembered it. Avoid duplicate notes and do not save routine chatter or unverified guesses. A hook reminder asks you to review missing capture; it does not require a write when nothing useful is missing.
+
 ## Where to Write — Decision Guide
 
 **Default to daily. Long-term is rare.**

--- a/skills/claude-code/SKILL.md
+++ b/skills/claude-code/SKILL.md
@@ -30,7 +30,13 @@ This deliberately fetches the full layer (today's log + MEMORY.md + yesterday's 
 2. Mark completed scratchpad items as done; add new follow-ups
 3. Only write to long-term memory if you discovered a **durable fact** that doesn't already exist there
 
-If Claude Code's `Stop` hook is installed, you may occasionally see a reminder to do this check even if you weren't planning to stop — that's the harness backing up this step for long sessions; treat it the same as the guidance above.
+If Claude Code's `Stop` hook is installed, you may occasionally see a reminder to do this check even if you weren't planning to stop — that's the harness checking for uncaptured work, including short sessions; treat it the same as the guidance above.
+
+## Capture at meaningful checkpoints
+
+When the user explicitly asks you to remember something, save it in that turn. After a decision is settled, a correction is accepted, or a fix is verified, record the useful outcome before reporting completion; do not wait for the session to end. Respect the user's memory and privacy preferences.
+
+Check whether that outcome was already saved. A write attempt is not a completed capture: verify the tool succeeded, and report a failed write rather than claiming you remembered it. Avoid duplicate notes and do not save routine chatter or unverified guesses. A hook reminder asks you to review missing capture; it does not require a write when nothing useful is missing.
 
 ## Where to Write — Decision Guide
 

--- a/skills/codex/SKILL.md
+++ b/skills/codex/SKILL.md
@@ -32,6 +32,12 @@ agent-memory search --query "<topic>" --mode keyword
 2. Mark completed scratchpad items as done; add new follow-ups
 3. Only write to long-term memory if you discovered a **durable fact** that doesn't already exist there
 
+## Capture at meaningful checkpoints
+
+When the user explicitly asks you to remember something, save it in that turn. After a decision is settled, a correction is accepted, or a fix is verified, record the useful outcome before reporting completion; do not wait for the session to end. Respect the user's memory and privacy preferences.
+
+Check whether that outcome was already saved. A write attempt is not a completed capture: verify the tool succeeded, and report a failed write rather than claiming you remembered it. Avoid duplicate notes and do not save routine chatter or unverified guesses. A hook reminder asks you to review missing capture; it does not require a write when nothing useful is missing.
+
 ## Where to Write — Decision Guide
 
 **Default to daily. Long-term is rare.**

--- a/skills/cursor/SKILL.md
+++ b/skills/cursor/SKILL.md
@@ -34,6 +34,12 @@ Run the context command above even if a `sessionStart` hook already fired (via `
 2. Mark completed scratchpad items as done; add new follow-ups
 3. Only write to long-term memory if you discovered a **durable fact** that doesn't already exist there
 
+## Capture at meaningful checkpoints
+
+When the user explicitly asks you to remember something, save it in that turn. After a decision is settled, a correction is accepted, or a fix is verified, record the useful outcome before reporting completion; do not wait for the session to end. Respect the user's memory and privacy preferences.
+
+Check whether that outcome was already saved. A write attempt is not a completed capture: verify the tool succeeded, and report a failed write rather than claiming you remembered it. Avoid duplicate notes and do not save routine chatter or unverified guesses. A hook reminder asks you to review missing capture; it does not require a write when nothing useful is missing.
+
 ## Where to Write — Decision Guide
 
 **Default to daily. Long-term is rare.**

--- a/skills/qoder/SKILL.md
+++ b/skills/qoder/SKILL.md
@@ -29,6 +29,12 @@ agent-memory context --no-search 2>/dev/null
 2. Mark completed scratchpad items as done; add new follow-ups
 3. Only write to long-term memory if you discovered a **durable fact** that doesn't already exist there
 
+## Capture at meaningful checkpoints
+
+When the user explicitly asks you to remember something, save it in that turn. After a decision is settled, a correction is accepted, or a fix is verified, record the useful outcome before reporting completion; do not wait for the session to end. Respect the user's memory and privacy preferences.
+
+Check whether that outcome was already saved. A write attempt is not a completed capture: verify the tool succeeded, and report a failed write rather than claiming you remembered it. Avoid duplicate notes and do not save routine chatter or unverified guesses. A hook reminder asks you to review missing capture; it does not require a write when nothing useful is missing.
+
 ## Where to Write — Decision Guide
 
 **Default to daily. Long-term is rare.**

--- a/src/capture-check.ts
+++ b/src/capture-check.ts
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+
+const MAX_TRANSCRIPT_BYTES = 512 * 1024;
+const EDIT_TOOLS = new Set(["Edit", "Write", "MultiEdit"]);
+
+type RecordValue = Record<string, unknown>;
+
+function record(value: unknown): RecordValue | undefined {
+	return value && typeof value === "object" && !Array.isArray(value) ? (value as RecordValue) : undefined;
+}
+
+function text(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (!Array.isArray(value)) return "";
+	return value.map((part) => (record(part)?.type === "text" ? String(record(part)?.text ?? "") : "")).join("\n");
+}
+
+function isMemoryWrite(tool: RecordValue): boolean {
+	const name = String(tool.name ?? "");
+	if (name === "memory_write" || name.endsWith("__memory_write")) return true;
+	if (name !== "Bash") return false;
+	const command = record(tool.input)?.command;
+	// Recognize an invocation, not a mention in echo/grep/another command's arguments.
+	return typeof command === "string" && /^\s*agent-memory\s+(?:write|save)\s/.test(command);
+}
+
+function successfulMemoryWrite(tool: RecordValue, result: RecordValue): boolean {
+	if (!isMemoryWrite(tool) || result.is_error === true) return false;
+	const output = text(result.content).trim();
+	if (/^(?:Appended to (?:daily log|MEMORY\.md|topic):?|Overwrote MEMORY\.md)\b/.test(output)) return true;
+	try {
+		const envelope = record(JSON.parse(output));
+		return envelope?.ok === true && ["daily", "long_term", "topic"].includes(String(envelope.target));
+	} catch {
+		return false;
+	}
+}
+
+/** Only identifiers are persisted by callers; transcript content never enters hook state. */
+export interface CaptureCheck {
+	pendingSignal?: string;
+}
+
+/**
+ * Detect high-confidence capture opportunities, not the semantic quality of a write.
+ * null means no usable transcript: callers can retain their periodic fallback.
+ */
+export function checkCaptureTranscript(transcriptPath: unknown, sessionId: string): CaptureCheck | null {
+	if (typeof transcriptPath !== "string" || !transcriptPath) return null;
+	let fd: number | undefined;
+	try {
+		fd = fs.openSync(transcriptPath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+		const stat = fs.fstatSync(fd);
+		if (!stat.isFile()) return null;
+		const start = Math.max(0, stat.size - MAX_TRANSCRIPT_BYTES);
+		const bytes = Buffer.alloc(Math.min(stat.size, MAX_TRANSCRIPT_BYTES));
+		const length = fs.readSync(fd, bytes, 0, bytes.length, start);
+		let content = bytes.subarray(0, length).toString("utf8");
+		if (start > 0) content = content.slice(content.indexOf("\n") + 1);
+		const tools = new Map<string, RecordValue>();
+		let pendingSignal: string | undefined;
+		let usable = false;
+		for (const line of content.split("\n")) {
+			let entry: RecordValue | undefined;
+			try {
+				entry = record(JSON.parse(line));
+			} catch {
+				continue;
+			}
+			if (!entry || entry.isSidechain === true || (entry.sessionId !== undefined && entry.sessionId !== sessionId))
+				continue;
+			if (entry.type !== "user" && entry.type !== "assistant") continue;
+			const message = record(entry.message);
+			if (!message) continue;
+			usable = true;
+			const signal = (id: string) => createHash("sha256").update(`${sessionId}\n${id}`).digest("hex");
+			if (entry.type === "user" && entry.isMeta !== true) {
+				const request = text(message.content);
+				const injected = /^(?:<system-reminder>|# (?:AGENTS|CLAUDE)\.md)/.test(request.trimStart());
+				if (
+					!injected &&
+					/\b(?:remember\s+(?:this|that|to)|don['’]t forget\s+(?:this|that|to))\b/i.test(request) &&
+					!/\b(?:don['’]t|do not|never)\s+remember\b/i.test(request)
+				) {
+					pendingSignal = signal(String(entry.uuid ?? line));
+				}
+			}
+			if (!Array.isArray(message.content)) continue;
+			for (const part of message.content) {
+				const block = record(part);
+				if (!block) continue;
+				if (entry.type === "assistant" && block.type === "tool_use" && typeof block.id === "string") {
+					tools.set(block.id, block);
+				} else if (entry.type === "user" && block.type === "tool_result" && typeof block.tool_use_id === "string") {
+					const tool = tools.get(block.tool_use_id);
+					if (!tool || block.is_error === true) continue;
+					if (EDIT_TOOLS.has(String(tool.name))) pendingSignal = signal(block.tool_use_id);
+					if (successfulMemoryWrite(tool, block)) pendingSignal = undefined;
+				}
+			}
+		}
+		return usable ? { pendingSignal } : null;
+	} catch {
+		return null;
+	} finally {
+		if (fd !== undefined) fs.closeSync(fd);
+	}
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,8 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
+import { type CaptureCheck, checkCaptureTranscript } from "./capture-check.js";
+
 import {
 	COMMAND_DESCRIPTIONS,
 	COMMAND_OPTIONS,
@@ -751,6 +753,7 @@ const STOP_NAG_INTERVAL = 6;
 const STOP_HOOK_MAX_SESSIONS = 50;
 
 interface StopHookSessionState {
+	lastCaptureSignal?: string;
 	count: number;
 	lastNagCount: number;
 	lastSeenAt: number;
@@ -788,13 +791,17 @@ function writeStopHookState(state: StopHookState): void {
  * corrupt or unwritable state file just means the nudge falls back to
  * "never fires" rather than breaking the Stop hook.
  */
-function shouldNagOnStop(sessionId: string, now: number): boolean {
+function shouldNagOnStop(sessionId: string, now: number, capture: CaptureCheck | null): boolean {
 	try {
 		const state = readStopHookState();
 		const existing = state.sessions[sessionId] ?? { count: 0, lastNagCount: 0, lastSeenAt: now };
 		const count = existing.count + 1;
-		const shouldNag = count - existing.lastNagCount >= STOP_NAG_INTERVAL;
+		const shouldNag = capture
+			? !!capture.pendingSignal &&
+				(capture.pendingSignal !== existing.lastCaptureSignal || count - existing.lastNagCount >= STOP_NAG_INTERVAL)
+			: count - existing.lastNagCount >= STOP_NAG_INTERVAL;
 		state.sessions[sessionId] = {
+			lastCaptureSignal: capture?.pendingSignal,
 			count,
 			lastNagCount: shouldNag ? count : existing.lastNagCount,
 			lastSeenAt: now,
@@ -814,9 +821,10 @@ const STOP_NAG_REASON =
 
 /**
  * Stop hook handler — fires at the end of every assistant turn (not once per
- * session). Continues the conversation at most once every STOP_NAG_INTERVAL
- * turns per session_id to nudge a memory-write check without being
- * disruptive. Uses `hookSpecificOutput.additionalContext` rather than
+ * session). Checks explicit remember requests and completed edits immediately
+ * when transcript evidence is available. A completed memory write clears the
+ * pending check; unchanged work is retried only every STOP_NAG_INTERVAL turns.
+ * Hosts without a usable transcript retain the periodic reminder. Uses `hookSpecificOutput.additionalContext` rather than
  * `decision: "block"` — functionally identical (both go through the same
  * `stop_hook_active` re-entry check and Claude Code's loop-protection cap),
  * but additionalContext renders as "Stop hook feedback" in the transcript
@@ -836,10 +844,15 @@ async function cmdStop(_flags: Record<string, string | boolean>): Promise<void> 
 	});
 
 	const work = (async () => {
-		const payload = await readStdinJson<{ session_id?: unknown; stop_hook_active?: unknown }>();
+		const payload = await readStdinJson<{
+			session_id?: unknown;
+			stop_hook_active?: unknown;
+			transcript_path?: unknown;
+		}>();
 		const sessionId = typeof payload?.session_id === "string" ? payload.session_id : "";
 		if (!sessionId || payload?.stop_hook_active === true) return;
-		if (shouldNagOnStop(sessionId, Date.now())) {
+		const capture = checkCaptureTranscript(payload?.transcript_path, sessionId);
+		if (shouldNagOnStop(sessionId, Date.now(), capture)) {
 			process.stdout.write(
 				JSON.stringify({
 					hookSpecificOutput: { hookEventName: "Stop", additionalContext: STOP_NAG_REASON },

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -529,7 +529,7 @@ describe("CLI subprocess", () => {
 		expect(stdout).toContain("Today's dynamic entry");
 	});
 
-	function runHookStop(sessionId: string, stopHookActive = false) {
+	function runHookStop(sessionId: string, stopHookActive = false, transcriptPath?: string) {
 		return Bun.spawnSync(
 			[
 				"bun",
@@ -543,12 +543,153 @@ describe("CLI subprocess", () => {
 				tmpDir,
 			],
 			{
-				stdin: Buffer.from(JSON.stringify({ session_id: sessionId, stop_hook_active: stopHookActive })),
+				stdin: Buffer.from(
+					JSON.stringify({
+						session_id: sessionId,
+						stop_hook_active: stopHookActive,
+						transcript_path: transcriptPath,
+					}),
+				),
 				stdout: "pipe",
 				stderr: "pipe",
 			},
 		);
 	}
+
+	function captureTranscript(records: unknown[]) {
+		const transcript = path.join(tmpDir, "capture-session.jsonl");
+		fs.writeFileSync(transcript, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+		return transcript;
+	}
+
+	function userMessage(text: string) {
+		return { type: "user", uuid: "request", message: { role: "user", content: text } };
+	}
+
+	function toolExchange(name: string, id: string, input: unknown, content: string, failed = false) {
+		return [
+			{ type: "assistant", message: { content: [{ type: "tool_use", id, name, input }] } },
+			{ type: "user", message: { content: [{ type: "tool_result", tool_use_id: id, content, is_error: failed }] } },
+		];
+	}
+
+	test("hook stop checks an explicit remember request on the first turn", () => {
+		const transcript = captureTranscript([userMessage("Remember this: staging uses PostgreSQL.")]);
+		const result = runHookStop("capture", false, transcript);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain("capture it now");
+		expect(runHookStop("capture", false, transcript).stdout.toString()).toBe("");
+		expect(runHookStop("capture", true, transcript).stdout.toString()).toBe("");
+	});
+
+	test("hook stop catches completed edits in short sessions but ignores failed edits", () => {
+		const transcript = captureTranscript(toolExchange("Edit", "edit", { file_path: "/repo/auth.ts" }, "Updated"));
+		expect(runHookStop("edited", false, transcript).stdout.toString()).toContain("capture it now");
+		captureTranscript(toolExchange("Edit", "failed", { file_path: "/repo/auth.ts" }, "Permission denied", true));
+		expect(runHookStop("failed", false, transcript).stdout.toString()).toBe("");
+	});
+
+	test("hook stop stays quiet for conversation without capture signals", () => {
+		const transcript = captureTranscript([userMessage("Hello, what is two plus two?")]);
+		for (let i = 0; i < 7; i++) expect(runHookStop("chat", false, transcript).stdout.toString()).toBe("");
+	});
+
+	test("hook stop acknowledges a successful memory write but not an attempted or failed write", () => {
+		const request = userMessage("Remember this: staging uses PostgreSQL.");
+		const written = toolExchange(
+			"Bash",
+			"write",
+			{ command: 'agent-memory write --content "staging uses PostgreSQL"' },
+			"Appended to daily log: /memory/daily/2026-09-08.md",
+		);
+		const transcript = captureTranscript([request, ...written]);
+		expect(runHookStop("written", false, transcript).stdout.toString()).toBe("");
+		captureTranscript([request, written[0]]);
+		expect(runHookStop("attempted", false, transcript).stdout.toString()).toContain("capture it now");
+		captureTranscript([
+			request,
+			...toolExchange(
+				"Bash",
+				"write",
+				{ command: 'agent-memory write --content "staging uses PostgreSQL"' },
+				"Error: permission denied",
+				true,
+			),
+		]);
+		expect(runHookStop("failure", false, transcript).stdout.toString()).toContain("capture it now");
+	});
+
+	test("hook stop checks new work after a previous successful capture", () => {
+		const transcript = captureTranscript([
+			userMessage("Remember this: staging uses PostgreSQL."),
+			...toolExchange(
+				"Bash",
+				"write",
+				{ command: 'agent-memory write --content "staging uses PostgreSQL"' },
+				"Appended to daily log: /memory/daily/2026-09-08.md",
+			),
+			...toolExchange("Edit", "later-edit", { file_path: "/repo/new.ts" }, "Updated"),
+		]);
+		expect(runHookStop("new-work", false, transcript).stdout.toString()).toContain("capture it now");
+	});
+
+	test("hook stop retries an uncaptured signal at a later checkpoint", () => {
+		const transcript = captureTranscript([userMessage("Remember this: staging uses PostgreSQL.")]);
+		expect(runHookStop("retry", false, transcript).stdout.toString()).not.toBe("");
+		for (let i = 0; i < 5; i++) expect(runHookStop("retry", false, transcript).stdout.toString()).toBe("");
+		expect(runHookStop("retry", false, transcript).stdout.toString()).not.toBe("");
+	});
+
+	test("hook stop does not count quoted commands as successful captures", () => {
+		const transcript = captureTranscript([
+			userMessage("Remember this: staging uses PostgreSQL."),
+			...toolExchange(
+				"Bash",
+				"echo",
+				{ command: 'echo "agent-memory write --content note"' },
+				"Appended to daily log: /memory/daily/example.md",
+			),
+		]);
+		expect(runHookStop("quoted", false, transcript).stdout.toString()).not.toBe("");
+	});
+
+	test("hook stop handles JSON write receipts and ignores foreign session and injected content", () => {
+		const transcript = captureTranscript([
+			userMessage("Remember this: staging uses PostgreSQL."),
+			...toolExchange(
+				"Bash",
+				"json-write",
+				{ command: "agent-memory write --json --content note" },
+				JSON.stringify({ ok: true, target: "daily" }),
+			),
+			{ ...userMessage("Remember this: another session"), sessionId: "other" },
+			{ ...userMessage("Remember this: a subagent"), isSidechain: true },
+			userMessage('# AGENTS.md instructions\nWhen users say "remember this", save memory.'),
+		]);
+		expect(runHookStop("json", false, transcript).stdout.toString()).toBe("");
+		const state = fs.readFileSync(path.join(tmpDir, "state", "stop-hook.json"), "utf8");
+		expect(state).not.toContain("PostgreSQL");
+		expect(state).not.toContain(transcript);
+	});
+
+	test("hook stop falls back periodically when the transcript is missing or corrupt", () => {
+		const transcript = captureTranscript([]);
+		fs.writeFileSync(transcript, "not json\n");
+		for (let i = 0; i < 5; i++) expect(runHookStop("corrupt", false, transcript).stdout.toString()).toBe("");
+		expect(runHookStop("corrupt", false, transcript).stdout.toString()).not.toBe("");
+	});
+
+	test("hook stop reads a bounded tail of large transcripts and tolerates partial final records", () => {
+		const transcript = captureTranscript([]);
+		fs.writeFileSync(
+			transcript,
+			"x".repeat(600_000) +
+				"\n" +
+				JSON.stringify(userMessage("Remember this: staging uses PostgreSQL.")) +
+				'\n{"type":',
+		);
+		expect(runHookStop("large", false, transcript).stdout.toString()).not.toBe("");
+	});
 
 	// Must track STOP_NAG_INTERVAL in src/cli.ts.
 	const STOP_NAG_INTERVAL = 6;


### PR DESCRIPTION
## Summary

Short sessions could finish after explicit "remember this" requests or completed edits without a capture check: the Claude Stop hook only reminded every six turns.

This adds a bounded transcript-tail check to the Claude Stop hook. It detects explicit memory requests and successful `Edit`, `Write`, and `MultiEdit` calls immediately, clears the pending signal after a verified AgentMemory write, and retries unchanged uncaptured work only at a later checkpoint. The fallback cadence remains for missing or unusable transcripts.

Bundled skills now direct agents to save useful outcomes at meaningful checkpoints, and the README documents the capture behavior and limits.

## Validation

- `bun test test/unit.test.ts test/cli.test.ts test/eval.test.ts test/token-savings.test.ts`
- `bun run build`
- `bun run build:lib`
- `bun run lint`
- Node CLI smoke test: first-turn reminder, successful write clears it, fresh process loads the saved fact.

## Behavior examples

- A first-turn `Remember this: staging uses PostgreSQL.` request now produces a capture check.
- A successful `agent-memory write` receipt clears the check.
- A failed write or an edit performed after the last capture remains eligible for a later check.
