### PR TITLE
eval: measure cross-harness capture reliability

### DIFF
--- a/docs/capture-reliability-eval.md
+++ b/docs/capture-reliability-eval.md
@@ -1,0 +1,30 @@
+# Cross-harness capture reliability evaluation
+
+AgentMemory can only recall a durable fact after some harness actually captures it. Retrieval quality therefore cannot stand in for capture reliability.
+
+`npm run eval:capture` reports the current capture contract across Claude Code, Codex, Cursor, Qoder, and Pi without treating unlike integrations as equivalent.
+
+## Enforcement classes
+
+- **mechanized** — AgentMemory itself observes a high-confidence capture opportunity and can deterministically verify whether a successful memory write cleared it.
+- **instruction-guided** — the installed skill tells the model to capture explicit memory requests and verified outcomes, but this repository cannot deterministically prove that a model followed the instruction on a real turn.
+- **delegated** — capture behavior is owned by another independently versioned package. Pi is delegated to `pi-memory`, so this repository does not count it in its measured denominator.
+
+## Metrics
+
+`instructionCoverage` is the fraction of locally measured harnesses whose shipped skill contains the required capture discipline: explicit memory requests are saved in-turn, write success is verified, and duplicate/routine notes are avoided.
+
+`mechanizedImmediateCoverage` is stricter. A harness only counts when AgentMemory can deterministically observe both an explicit memory request and completed work as pending capture signals. A successful AgentMemory write must also clear the signal for the mechanized path to pass.
+
+The initial expected baseline after the reliable Claude Stop capture check is:
+
+- measured local harnesses: 4 (`claude`, `codex`, `cursor`, `qoder`)
+- instruction coverage: 100%
+- mechanized immediate coverage: 25% (`claude` only)
+- delegated harnesses: 1 (`pi` via `pi-memory`)
+
+The 25% value is not a failure of the evaluator. It is the remaining product gap made measurable. Future host-specific mechanisms should raise this number only when CI can prove the behavior, not when documentation merely claims it.
+
+## What this does not claim
+
+This evaluation does not claim that every eligible fact is semantically worth saving, that a model always obeys an installed skill, or that a captured note is useful later. Those require separate behavioral/longitudinal evaluations. It also does not import `pi-memory` internals into AgentMemory; Pi should have its own equivalent capture evaluation in that repository and can later be joined through a versioned cross-repo compatibility lane.

--- a/eval/capture-reliability.ts
+++ b/eval/capture-reliability.ts
@@ -1,0 +1,161 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { checkCaptureTranscript, isExplicitMemoryRequest } from "../src/capture-check.js";
+
+export type CaptureHarness = "claude" | "codex" | "cursor" | "qoder" | "pi";
+export type CaptureEnforcement = "mechanized" | "instruction-guided" | "delegated";
+
+export interface CaptureHarnessResult {
+	harness: CaptureHarness;
+	enforcement: CaptureEnforcement;
+	measured: boolean;
+	instructionContract: boolean | null;
+	mechanizedExplicitRequest: boolean | null;
+	mechanizedCompletedWork: boolean | null;
+	mechanizedWriteClearsSignal: boolean | null;
+	notes: string[];
+}
+
+export interface CaptureReliabilityReport {
+	schemaVersion: "capture-reliability-v1";
+	harnesses: CaptureHarnessResult[];
+	metrics: {
+		measuredHarnesses: number;
+		instructionCoverage: number;
+		mechanizedImmediateCoverage: number;
+		delegatedHarnesses: number;
+	};
+	passed: boolean;
+}
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const REQUIRED_GUIDANCE = [
+	"When the user explicitly asks you to remember something, save it in that turn.",
+	"verify the tool succeeded",
+	"Avoid duplicate notes",
+];
+
+const LOCAL_SKILLS: Array<{ harness: Exclude<CaptureHarness, "pi">; path: string }> = [
+	{ harness: "claude", path: "skills/claude-code/SKILL.md" },
+	{ harness: "codex", path: "skills/codex/SKILL.md" },
+	{ harness: "cursor", path: "skills/cursor/SKILL.md" },
+	{ harness: "qoder", path: "skills/qoder/SKILL.md" },
+];
+
+function skillHasCaptureContract(relativePath: string): boolean {
+	try {
+		const content = fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+		return REQUIRED_GUIDANCE.every((marker) => content.includes(marker));
+	} catch {
+		return false;
+	}
+}
+
+function writeTranscript(records: unknown[]): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-memory-capture-eval-"));
+	const transcript = path.join(dir, "session.jsonl");
+	fs.writeFileSync(transcript, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+	return transcript;
+}
+
+function userMessage(text: string): unknown {
+	return { type: "user", uuid: "request", message: { role: "user", content: text } };
+}
+
+function toolExchange(name: string, id: string, input: unknown, content: string): unknown[] {
+	return [
+		{ type: "assistant", message: { content: [{ type: "tool_use", id, name, input }] } },
+		{ type: "user", message: { content: [{ type: "tool_result", tool_use_id: id, content }] } },
+	];
+}
+
+function evaluateClaudeMechanism(): Pick<
+	CaptureHarnessResult,
+	"mechanizedExplicitRequest" | "mechanizedCompletedWork" | "mechanizedWriteClearsSignal" | "notes"
+> {
+	const paths: string[] = [];
+	try {
+		const explicit = writeTranscript([userMessage("Remember this: staging uses PostgreSQL.")]);
+		paths.push(explicit);
+		const completed = writeTranscript(toolExchange("Edit", "edit-1", { file_path: "/repo/auth.ts" }, "Updated"));
+		paths.push(completed);
+		const cleared = writeTranscript([
+			userMessage("Remember this: staging uses PostgreSQL."),
+			...toolExchange(
+				"Bash",
+				"write-1",
+				{ command: 'agent-memory write --content "staging uses PostgreSQL"' },
+				"Appended to daily log: /memory/daily/2026-09-08.md",
+			),
+		]);
+		paths.push(cleared);
+		return {
+			mechanizedExplicitRequest: Boolean(checkCaptureTranscript(explicit, "capture-eval")?.pendingSignal),
+			mechanizedCompletedWork: Boolean(checkCaptureTranscript(completed, "capture-eval")?.pendingSignal),
+			mechanizedWriteClearsSignal: checkCaptureTranscript(cleared, "capture-eval")?.pendingSignal === undefined,
+			notes: ["Claude is the only local harness with a transcript-aware Stop capture check."],
+		};
+	} finally {
+		for (const transcript of paths) fs.rmSync(path.dirname(transcript), { recursive: true, force: true });
+	}
+}
+
+export function runCaptureReliabilityEvaluation(): CaptureReliabilityReport {
+	const claudeMechanism = evaluateClaudeMechanism();
+	const localResults = LOCAL_SKILLS.map<CaptureHarnessResult>(({ harness, path: skillPath }) => ({
+		harness,
+		enforcement: harness === "claude" ? "mechanized" : "instruction-guided",
+		measured: true,
+		instructionContract: skillHasCaptureContract(skillPath),
+		mechanizedExplicitRequest: harness === "claude" ? claudeMechanism.mechanizedExplicitRequest : null,
+		mechanizedCompletedWork: harness === "claude" ? claudeMechanism.mechanizedCompletedWork : null,
+		mechanizedWriteClearsSignal: harness === "claude" ? claudeMechanism.mechanizedWriteClearsSignal : null,
+		notes:
+			harness === "claude"
+				? claudeMechanism.notes
+				: ["Capture relies on the installed skill/checkpoint discipline; model compliance is not deterministically measured here."],
+	}));
+	const pi: CaptureHarnessResult = {
+		harness: "pi",
+		enforcement: "delegated",
+		measured: false,
+		instructionContract: null,
+		mechanizedExplicitRequest: null,
+		mechanizedCompletedWork: null,
+		mechanizedWriteClearsSignal: null,
+		notes: ["Pi capture is delegated to the separately versioned pi-memory extension and is intentionally excluded from this repo's denominator."],
+	};
+	const harnesses = [...localResults, pi];
+	const measured = harnesses.filter((result) => result.measured);
+	const instructionCoverage = measured.filter((result) => result.instructionContract).length / measured.length;
+	const mechanizedImmediateCoverage =
+		measured.filter(
+			(result) => result.mechanizedExplicitRequest === true && result.mechanizedCompletedWork === true,
+		).length / measured.length;
+	const passed =
+		instructionCoverage === 1 &&
+		claudeMechanism.mechanizedExplicitRequest === true &&
+		claudeMechanism.mechanizedCompletedWork === true &&
+		claudeMechanism.mechanizedWriteClearsSignal === true &&
+		isExplicitMemoryRequest("Remember this: staging uses PostgreSQL.") &&
+		!isExplicitMemoryRequest("Do not remember this: staging uses PostgreSQL.");
+	return {
+		schemaVersion: "capture-reliability-v1",
+		harnesses,
+		metrics: {
+			measuredHarnesses: measured.length,
+			instructionCoverage,
+			mechanizedImmediateCoverage,
+			delegatedHarnesses: harnesses.filter((result) => result.enforcement === "delegated").length,
+		},
+		passed,
+	};
+}
+
+if (import.meta.main) {
+	const report = runCaptureReliabilityEvaluation();
+	process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+	if (!report.passed) process.exitCode = 1;
+}

--- a/eval/capture-reliability.ts
+++ b/eval/capture-reliability.ts
@@ -91,10 +91,13 @@ function evaluateClaudeMechanism(): Pick<
 			),
 		]);
 		paths.push(cleared);
+		const explicitCheck = checkCaptureTranscript(explicit, "capture-eval");
+		const completedCheck = checkCaptureTranscript(completed, "capture-eval");
+		const clearedCheck = checkCaptureTranscript(cleared, "capture-eval");
 		return {
-			mechanizedExplicitRequest: Boolean(checkCaptureTranscript(explicit, "capture-eval")?.pendingSignal),
-			mechanizedCompletedWork: Boolean(checkCaptureTranscript(completed, "capture-eval")?.pendingSignal),
-			mechanizedWriteClearsSignal: checkCaptureTranscript(cleared, "capture-eval")?.pendingSignal === undefined,
+			mechanizedExplicitRequest: Boolean(explicitCheck?.pendingSignal),
+			mechanizedCompletedWork: Boolean(completedCheck?.pendingSignal),
+			mechanizedWriteClearsSignal: clearedCheck !== null && clearedCheck.pendingSignal === undefined,
 			notes: ["Claude is the only local harness with a transcript-aware Stop capture check."],
 		};
 	} finally {

--- a/eval/capture-reliability.ts
+++ b/eval/capture-reliability.ts
@@ -118,7 +118,9 @@ export function runCaptureReliabilityEvaluation(): CaptureReliabilityReport {
 		notes:
 			harness === "claude"
 				? claudeMechanism.notes
-				: ["Capture relies on the installed skill/checkpoint discipline; model compliance is not deterministically measured here."],
+				: [
+						"Capture relies on the installed skill/checkpoint discipline; model compliance is not deterministically measured here.",
+					],
 	}));
 	const pi: CaptureHarnessResult = {
 		harness: "pi",
@@ -128,15 +130,16 @@ export function runCaptureReliabilityEvaluation(): CaptureReliabilityReport {
 		mechanizedExplicitRequest: null,
 		mechanizedCompletedWork: null,
 		mechanizedWriteClearsSignal: null,
-		notes: ["Pi capture is delegated to the separately versioned pi-memory extension and is intentionally excluded from this repo's denominator."],
+		notes: [
+			"Pi capture is delegated to the separately versioned pi-memory extension and is intentionally excluded from this repo's denominator.",
+		],
 	};
 	const harnesses = [...localResults, pi];
 	const measured = harnesses.filter((result) => result.measured);
 	const instructionCoverage = measured.filter((result) => result.instructionContract).length / measured.length;
 	const mechanizedImmediateCoverage =
-		measured.filter(
-			(result) => result.mechanizedExplicitRequest === true && result.mechanizedCompletedWork === true,
-		).length / measured.length;
+		measured.filter((result) => result.mechanizedExplicitRequest === true && result.mechanizedCompletedWork === true)
+			.length / measured.length;
 	const passed =
 		instructionCoverage === 1 &&
 		claudeMechanism.mechanizedExplicitRequest === true &&

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
 		"eval:regression": "bun eval/run.ts --dataset eval/datasets/agent-memory-regression-v1.json",
 		"eval:longmemeval": "bun eval/longmemeval.ts",
 		"eval:token-savings": "bun eval/token-savings.ts",
+		"eval:capture": "bun eval/capture-reliability.ts",
 		"prepare": "npm run build:lib",
 		"prepack": "npm run build:lib",
 		"lint": "biome check .",

--- a/src/capture-check.ts
+++ b/src/capture-check.ts
@@ -16,6 +16,15 @@ function text(value: unknown): string {
 	return value.map((part) => (record(part)?.type === "text" ? String(record(part)?.text ?? "") : "")).join("\n");
 }
 
+export function isExplicitMemoryRequest(value: unknown): boolean {
+	if (typeof value !== "string") return false;
+	const request = value.trim();
+	if (!request) return false;
+	if (/^(?:<system-reminder>|# (?:AGENTS|CLAUDE)\.md)/.test(request)) return false;
+	if (/\b(?:don['’]t|do not|never)\s+remember\b/i.test(request)) return false;
+	return /\b(?:remember\s+(?:this|that|to)|don['’]t forget\s+(?:this|that|to))\b/i.test(request);
+}
+
 function isMemoryWrite(tool: RecordValue): boolean {
 	const name = String(tool.name ?? "");
 	if (name === "memory_write" || name.endsWith("__memory_write")) return true;
@@ -77,14 +86,7 @@ export function checkCaptureTranscript(transcriptPath: unknown, sessionId: strin
 			const signal = (id: string) => createHash("sha256").update(`${sessionId}\n${id}`).digest("hex");
 			if (entry.type === "user" && entry.isMeta !== true) {
 				const request = text(message.content);
-				const injected = /^(?:<system-reminder>|# (?:AGENTS|CLAUDE)\.md)/.test(request.trimStart());
-				if (
-					!injected &&
-					/\b(?:remember\s+(?:this|that|to)|don['’]t forget\s+(?:this|that|to))\b/i.test(request) &&
-					!/\b(?:don['’]t|do not|never)\s+remember\b/i.test(request)
-				) {
-					pendingSignal = signal(String(entry.uuid ?? line));
-				}
+				if (isExplicitMemoryRequest(request)) pendingSignal = signal(String(entry.uuid ?? line));
 			}
 			if (!Array.isArray(message.content)) continue;
 			for (const part of message.content) {

--- a/test/eval.test.ts
+++ b/test/eval.test.ts
@@ -3,11 +3,38 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
+import { runCaptureReliabilityEvaluation } from "../eval/capture-reliability.js";
 import { loadFeedbackDataset, validateFeedbackDataset } from "../eval/dataset.js";
 import { buildFixtureWriteParams, calculateRetrievalMetrics, runFeedbackEvaluation } from "../eval/run.js";
 
 const datasetUrl = new URL("../eval/datasets/external-feedback-v1.json", import.meta.url);
 const expandedDatasetUrl = new URL("../eval/datasets/agent-memory-regression-v1.json", import.meta.url);
+
+describe("cross-harness capture reliability", () => {
+	test("measures local harness contracts without overstating delegated Pi coverage", () => {
+		const report = runCaptureReliabilityEvaluation();
+		expect(report.passed).toBe(true);
+		expect(report.schemaVersion).toBe("capture-reliability-v1");
+		expect(report.metrics.measuredHarnesses).toBe(4);
+		expect(report.metrics.instructionCoverage).toBe(1);
+		expect(report.metrics.mechanizedImmediateCoverage).toBe(0.25);
+		expect(report.metrics.delegatedHarnesses).toBe(1);
+		const claude = report.harnesses.find((result) => result.harness === "claude");
+		expect(claude?.enforcement).toBe("mechanized");
+		expect(claude?.mechanizedExplicitRequest).toBe(true);
+		expect(claude?.mechanizedCompletedWork).toBe(true);
+		expect(claude?.mechanizedWriteClearsSignal).toBe(true);
+		for (const harness of ["codex", "cursor", "qoder"]) {
+			const result = report.harnesses.find((entry) => entry.harness === harness);
+			expect(result?.instructionContract).toBe(true);
+			expect(result?.enforcement).toBe("instruction-guided");
+			expect(result?.mechanizedExplicitRequest).toBeNull();
+		}
+		const pi = report.harnesses.find((result) => result.harness === "pi");
+		expect(pi?.enforcement).toBe("delegated");
+		expect(pi?.measured).toBe(false);
+	});
+});
 
 describe("external feedback evaluation dataset", () => {
 	test("covers every automatable issue with unique, valid probes", async () => {


### PR DESCRIPTION
## Why

PR #25 closes the first concrete capture hole by making Claude's Stop hook detect uncaptured explicit memory requests and completed edits. The next gap is measurement: Claude, Codex, Cursor, Qoder, and Pi do not have equivalent enforcement mechanisms, and treating skill guidance as if it were deterministic capture would overstate reliability.

This PR adds a cross-harness capture evaluation that makes those differences explicit and turns the remaining gap into a measurable baseline.

## What

- add `eval/capture-reliability.ts` and `npm run eval:capture`
- classify each harness as `mechanized`, `instruction-guided`, or `delegated`
- measure the four locally owned harnesses (`claude`, `codex`, `cursor`, `qoder`) against the same capture instruction contract
- exercise Claude's transcript-aware mechanism with deterministic fixtures for:
  - explicit remember requests
  - completed edits
  - successful memory writes clearing the pending signal
- exclude Pi from the local denominator because AgentMemory delegates Pi behavior to the separately versioned `pi-memory` package
- expose `isExplicitMemoryRequest()` so the detector has one tested definition rather than duplicated regexes
- document metric semantics and non-claims

## Baseline

The expected current baseline is intentionally not 100%:

- instruction coverage: **100%** across the four locally measured harnesses
- mechanized immediate capture coverage: **25%** (Claude only)
- delegated harnesses: **1** (Pi via `pi-memory`)

That 25% is the product gap, not an evaluator failure. A future PR should raise it only by adding host-specific deterministic mechanisms with CI proof.

## Validation

The existing `test:eval` suite now gates the report and verifies:
- all four local harnesses ship the required capture guidance
- Claude observes explicit requests and completed edits
- a successful AgentMemory write clears Claude's pending signal
- Codex/Cursor/Qoder remain honestly classified as instruction-guided rather than mechanized
- Pi remains delegated/unmeasured in this repository

## Stack

This PR is intentionally stacked on #25 because it evaluates the capture contract introduced there. Once #25 merges, this PR can be retargeted to `main` without changing its semantic diff.
