### PR TITLE
feat: mechanize explicit-memory capture checks in Codex

### DIFF
--- a/docs/capture-reliability-eval.md
+++ b/docs/capture-reliability-eval.md
@@ -6,7 +6,8 @@ AgentMemory can only recall a durable fact after some harness actually captures 
 
 ## Enforcement classes
 
-- **mechanized** — AgentMemory itself observes a high-confidence capture opportunity and can deterministically verify whether a successful memory write cleared it.
+- **mechanized** — AgentMemory itself observes the evaluated capture opportunities and can deterministically verify the relevant path.
+- **partially-mechanized** — at least one capture opportunity is deterministically surfaced by AgentMemory, while other important capture paths remain instruction-guided or unproven. Codex is in this class because `UserPromptSubmit` now injects an explicit-memory-request capture check, but completed-work capture is not yet proven against Codex transcripts.
 - **instruction-guided** — the installed skill tells the model to capture explicit memory requests and verified outcomes, but this repository cannot deterministically prove that a model followed the instruction on a real turn.
 - **delegated** — capture behavior is owned by another independently versioned package. Pi is delegated to `pi-memory`, so this repository does not count it in its measured denominator.
 
@@ -14,16 +15,19 @@ AgentMemory can only recall a durable fact after some harness actually captures 
 
 `instructionCoverage` is the fraction of locally measured harnesses whose shipped skill contains the required capture discipline: explicit memory requests are saved in-turn, write success is verified, and duplicate/routine notes are avoided.
 
-`mechanizedImmediateCoverage` is stricter. A harness only counts when AgentMemory can deterministically observe both an explicit memory request and completed work as pending capture signals. A successful AgentMemory write must also clear the signal for the mechanized path to pass.
+`mechanizedExplicitRequestCoverage` measures the narrower question: for how many locally measured harnesses can AgentMemory deterministically surface an explicit user request to remember something? After the Codex `UserPromptSubmit` capture check, this is 50% (`claude` + `codex`).
 
-The initial expected baseline after the reliable Claude Stop capture check is:
+`mechanizedImmediateCoverage` remains stricter. A harness only counts when AgentMemory can deterministically observe both an explicit memory request and completed work as pending capture signals. A successful AgentMemory write must also clear the signal for the fully mechanized path to pass.
+
+The expected baseline after the Codex explicit-request change is:
 
 - measured local harnesses: 4 (`claude`, `codex`, `cursor`, `qoder`)
 - instruction coverage: 100%
+- mechanized explicit-request coverage: 50% (`claude`, `codex`)
 - mechanized immediate coverage: 25% (`claude` only)
 - delegated harnesses: 1 (`pi` via `pi-memory`)
 
-The 25% value is not a failure of the evaluator. It is the remaining product gap made measurable. Future host-specific mechanisms should raise this number only when CI can prove the behavior, not when documentation merely claims it.
+The gap between 50% explicit-request coverage and 25% full immediate coverage is intentional and informative: Codex completed-work capture still needs a deterministic mechanism and compatibility proof. Future host-specific mechanisms should raise the stricter number only when CI can prove the behavior, not when documentation merely claims it.
 
 ## What this does not claim
 

--- a/eval/capture-reliability.ts
+++ b/eval/capture-reliability.ts
@@ -114,7 +114,8 @@ function evaluateCodexPromptMechanism(): Pick<CaptureHarnessResult, "mechanizedE
 		mechanizedExplicitRequest:
 			explicit.some(
 				(section) =>
-					section.id === "core.capture.explicit-memory-request" && section.content.includes("Save the durable fact in this turn"),
+					section.id === "core.capture.explicit-memory-request" &&
+					section.content.includes("Save the durable fact in this turn"),
 			) && negative.length === 0,
 		notes: [
 			"Codex UserPromptSubmit deterministically injects a Core capture check for explicit memory requests.",

--- a/eval/capture-reliability.ts
+++ b/eval/capture-reliability.ts
@@ -3,9 +3,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { checkCaptureTranscript, isExplicitMemoryRequest } from "../src/capture-check.js";
+import { coreCaptureContextForQuery } from "../src/plugin-runtime.js";
 
 export type CaptureHarness = "claude" | "codex" | "cursor" | "qoder" | "pi";
-export type CaptureEnforcement = "mechanized" | "instruction-guided" | "delegated";
+export type CaptureEnforcement = "mechanized" | "partially-mechanized" | "instruction-guided" | "delegated";
 
 export interface CaptureHarnessResult {
 	harness: CaptureHarness;
@@ -24,6 +25,7 @@ export interface CaptureReliabilityReport {
 	metrics: {
 		measuredHarnesses: number;
 		instructionCoverage: number;
+		mechanizedExplicitRequestCoverage: number;
 		mechanizedImmediateCoverage: number;
 		delegatedHarnesses: number;
 	};
@@ -98,30 +100,70 @@ function evaluateClaudeMechanism(): Pick<
 			mechanizedExplicitRequest: Boolean(explicitCheck?.pendingSignal),
 			mechanizedCompletedWork: Boolean(completedCheck?.pendingSignal),
 			mechanizedWriteClearsSignal: clearedCheck !== null && clearedCheck.pendingSignal === undefined,
-			notes: ["Claude is the only local harness with a transcript-aware Stop capture check."],
+			notes: ["Claude has a transcript-aware Stop capture check for explicit requests and completed work."],
 		};
 	} finally {
 		for (const transcript of paths) fs.rmSync(path.dirname(transcript), { recursive: true, force: true });
 	}
 }
 
+function evaluateCodexPromptMechanism(): Pick<CaptureHarnessResult, "mechanizedExplicitRequest" | "notes"> {
+	const explicit = coreCaptureContextForQuery("Remember this: staging uses PostgreSQL.");
+	const negative = coreCaptureContextForQuery("Do not remember this: staging uses PostgreSQL.");
+	return {
+		mechanizedExplicitRequest:
+			explicit.some(
+				(section) =>
+					section.id === "core.capture.explicit-memory-request" && section.content.includes("Save the durable fact in this turn"),
+			) && negative.length === 0,
+		notes: [
+			"Codex UserPromptSubmit deterministically injects a Core capture check for explicit memory requests.",
+			"Completed-work capture remains instruction-guided until Codex transcript/Stop compatibility is proven.",
+		],
+	};
+}
+
 export function runCaptureReliabilityEvaluation(): CaptureReliabilityReport {
 	const claudeMechanism = evaluateClaudeMechanism();
-	const localResults = LOCAL_SKILLS.map<CaptureHarnessResult>(({ harness, path: skillPath }) => ({
-		harness,
-		enforcement: harness === "claude" ? "mechanized" : "instruction-guided",
-		measured: true,
-		instructionContract: skillHasCaptureContract(skillPath),
-		mechanizedExplicitRequest: harness === "claude" ? claudeMechanism.mechanizedExplicitRequest : null,
-		mechanizedCompletedWork: harness === "claude" ? claudeMechanism.mechanizedCompletedWork : null,
-		mechanizedWriteClearsSignal: harness === "claude" ? claudeMechanism.mechanizedWriteClearsSignal : null,
-		notes:
-			harness === "claude"
-				? claudeMechanism.notes
-				: [
-						"Capture relies on the installed skill/checkpoint discipline; model compliance is not deterministically measured here.",
-					],
-	}));
+	const codexMechanism = evaluateCodexPromptMechanism();
+	const localResults = LOCAL_SKILLS.map<CaptureHarnessResult>(({ harness, path: skillPath }) => {
+		if (harness === "claude") {
+			return {
+				harness,
+				enforcement: "mechanized",
+				measured: true,
+				instructionContract: skillHasCaptureContract(skillPath),
+				mechanizedExplicitRequest: claudeMechanism.mechanizedExplicitRequest,
+				mechanizedCompletedWork: claudeMechanism.mechanizedCompletedWork,
+				mechanizedWriteClearsSignal: claudeMechanism.mechanizedWriteClearsSignal,
+				notes: claudeMechanism.notes,
+			};
+		}
+		if (harness === "codex") {
+			return {
+				harness,
+				enforcement: "partially-mechanized",
+				measured: true,
+				instructionContract: skillHasCaptureContract(skillPath),
+				mechanizedExplicitRequest: codexMechanism.mechanizedExplicitRequest,
+				mechanizedCompletedWork: null,
+				mechanizedWriteClearsSignal: null,
+				notes: codexMechanism.notes,
+			};
+		}
+		return {
+			harness,
+			enforcement: "instruction-guided",
+			measured: true,
+			instructionContract: skillHasCaptureContract(skillPath),
+			mechanizedExplicitRequest: null,
+			mechanizedCompletedWork: null,
+			mechanizedWriteClearsSignal: null,
+			notes: [
+				"Capture relies on the installed skill/checkpoint discipline; model compliance is not deterministically measured here.",
+			],
+		};
+	});
 	const pi: CaptureHarnessResult = {
 		harness: "pi",
 		enforcement: "delegated",
@@ -137,14 +179,17 @@ export function runCaptureReliabilityEvaluation(): CaptureReliabilityReport {
 	const harnesses = [...localResults, pi];
 	const measured = harnesses.filter((result) => result.measured);
 	const instructionCoverage = measured.filter((result) => result.instructionContract).length / measured.length;
+	const mechanizedExplicitRequestCoverage =
+		measured.filter((result) => result.mechanizedExplicitRequest === true).length / measured.length;
 	const mechanizedImmediateCoverage =
 		measured.filter((result) => result.mechanizedExplicitRequest === true && result.mechanizedCompletedWork === true)
 			.length / measured.length;
 	const passed =
 		instructionCoverage === 1 &&
-		claudeMechanism.mechanizedExplicitRequest === true &&
-		claudeMechanism.mechanizedCompletedWork === true &&
+		mechanizedExplicitRequestCoverage === 0.5 &&
+		mechanizedImmediateCoverage === 0.25 &&
 		claudeMechanism.mechanizedWriteClearsSignal === true &&
+		codexMechanism.mechanizedExplicitRequest === true &&
 		isExplicitMemoryRequest("Remember this: staging uses PostgreSQL.") &&
 		!isExplicitMemoryRequest("Do not remember this: staging uses PostgreSQL.");
 	return {
@@ -153,6 +198,7 @@ export function runCaptureReliabilityEvaluation(): CaptureReliabilityReport {
 		metrics: {
 			measuredHarnesses: measured.length,
 			instructionCoverage,
+			mechanizedExplicitRequestCoverage,
 			mechanizedImmediateCoverage,
 			delegatedHarnesses: harnesses.filter((result) => result.enforcement === "delegated").length,
 		},

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { isExplicitMemoryRequest } from "./capture-check.js";
 import { getMemoryDir, memoryWrite, redactSecrets, scheduleQmdUpdate } from "./core.js";
 import {
 	FilePluginInstallStore,
@@ -52,6 +53,18 @@ export interface PluginRuntimeOptionsV1 {
 	coreVersion: string;
 	store?: PluginInstallStoreV1;
 	backend?: PluginBootstrapBackendV1;
+}
+
+export function coreCaptureContextForQuery(query?: string): PluginContextSectionV1[] {
+	if (!query || !isExplicitMemoryRequest(query)) return [];
+	return [
+		{
+			id: "core.capture.explicit-memory-request",
+			label: "AgentMemory capture check",
+			content:
+				"The user explicitly asked you to remember something. Save the durable fact in this turn using AgentMemory, verify the write succeeded, and do not claim it was remembered if the write failed. Avoid duplicate notes and respect explicit privacy or forget instructions.",
+		},
+	];
 }
 
 function assertPermission(manifest: AgentMemoryPluginManifestV1, permission: string): void {
@@ -104,7 +117,7 @@ async function importBundle(
 		throw new PluginBootstrapFailure(
 			"plugin_entrypoint_invalid",
 			"The installed plugin entrypoint is not a regular file",
-		);
+			);
 	const imported = (await import(`${pathToFileURL(entrypoint).href}?v=${encodeURIComponent(receipt.version)}`)) as {
 		default?: unknown;
 	};
@@ -238,9 +251,9 @@ export class InstalledPluginRuntimeV1 {
 		query?: string;
 		signal: AbortSignal;
 	}): Promise<PluginContextSectionV1[]> {
-		if (!(await this.load()) || this.contextProviders.length === 0) return [];
+		const sections = coreCaptureContextForQuery(context.query);
+		if (!(await this.load()) || this.contextProviders.length === 0) return sections;
 		const entitlement = await this.refreshEntitlement();
-		const sections: PluginContextSectionV1[] = [];
 		for (const registered of this.contextProviders) {
 			if (!isPluginCapabilityEnabled(entitlement, registered.provider.requiredCapability)) continue;
 			const provided = await registered.provider.provide(context);

--- a/src/plugin-runtime.ts
+++ b/src/plugin-runtime.ts
@@ -117,7 +117,7 @@ async function importBundle(
 		throw new PluginBootstrapFailure(
 			"plugin_entrypoint_invalid",
 			"The installed plugin entrypoint is not a regular file",
-			);
+		);
 	const imported = (await import(`${pathToFileURL(entrypoint).href}?v=${encodeURIComponent(receipt.version)}`)) as {
 		default?: unknown;
 	};

--- a/test/eval.test.ts
+++ b/test/eval.test.ts
@@ -11,25 +11,36 @@ const datasetUrl = new URL("../eval/datasets/external-feedback-v1.json", import.
 const expandedDatasetUrl = new URL("../eval/datasets/agent-memory-regression-v1.json", import.meta.url);
 
 describe("cross-harness capture reliability", () => {
-	test("measures local harness contracts without overstating delegated Pi coverage", () => {
+	test("measures partial Codex mechanization without overstating completed-work coverage", () => {
 		const report = runCaptureReliabilityEvaluation();
 		expect(report.passed).toBe(true);
 		expect(report.schemaVersion).toBe("capture-reliability-v1");
 		expect(report.metrics.measuredHarnesses).toBe(4);
 		expect(report.metrics.instructionCoverage).toBe(1);
+		expect(report.metrics.mechanizedExplicitRequestCoverage).toBe(0.5);
 		expect(report.metrics.mechanizedImmediateCoverage).toBe(0.25);
 		expect(report.metrics.delegatedHarnesses).toBe(1);
+
 		const claude = report.harnesses.find((result) => result.harness === "claude");
 		expect(claude?.enforcement).toBe("mechanized");
 		expect(claude?.mechanizedExplicitRequest).toBe(true);
 		expect(claude?.mechanizedCompletedWork).toBe(true);
 		expect(claude?.mechanizedWriteClearsSignal).toBe(true);
-		for (const harness of ["codex", "cursor", "qoder"]) {
+
+		const codex = report.harnesses.find((result) => result.harness === "codex");
+		expect(codex?.instructionContract).toBe(true);
+		expect(codex?.enforcement).toBe("partially-mechanized");
+		expect(codex?.mechanizedExplicitRequest).toBe(true);
+		expect(codex?.mechanizedCompletedWork).toBeNull();
+		expect(codex?.mechanizedWriteClearsSignal).toBeNull();
+
+		for (const harness of ["cursor", "qoder"]) {
 			const result = report.harnesses.find((entry) => entry.harness === harness);
 			expect(result?.instructionContract).toBe(true);
 			expect(result?.enforcement).toBe("instruction-guided");
 			expect(result?.mechanizedExplicitRequest).toBeNull();
 		}
+
 		const pi = report.harnesses.find((result) => result.harness === "pi");
 		expect(pi?.enforcement).toBe("delegated");
 		expect(pi?.measured).toBe(false);

--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -2668,15 +2668,42 @@ describe("temporary plugin activation and runtime", () => {
 				await runtime.provideContext({
 					host: "codex",
 					cwd: "/tmp/project",
-					query: "remember this",
+					query: "project status",
 					signal: context.signal,
 				}),
-			).toEqual([{ id: "runtime-section", label: "## Runtime context", content: "remember this" }]);
+			).toEqual([{ id: "runtime-section", label: "## Runtime context", content: "project status" }]);
 			backend.entitlement.capabilities.learning.enabled = false;
 			expect((await runtime.run("runtime-ping", context))?.error?.code).toBe("plugin_capability_denied");
 			expect(await runtime.provideContext({ host: "codex", cwd: "/tmp/project", signal: context.signal })).toEqual(
 				[],
 			);
+		} finally {
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("provideContext surfaces the core capture check even without an installed Pro bundle", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "agent-memory-runtime-no-bundle-"));
+		try {
+			const runtime = new InstalledPluginRuntimeV1({
+				coreVersion: "0.4.13",
+				store: new FilePluginInstallStore(root),
+				backend: new FakePluginBackend(),
+			});
+			const signal = new AbortController().signal;
+			expect(
+				await runtime.provideContext({ host: "codex", cwd: "/tmp/project", query: "remember this", signal }),
+			).toEqual([
+				{
+					id: "core.capture.explicit-memory-request",
+					label: "AgentMemory capture check",
+					content:
+						"The user explicitly asked you to remember something. Save the durable fact in this turn using AgentMemory, verify the write succeeded, and do not claim it was remembered if the write failed. Avoid duplicate notes and respect explicit privacy or forget instructions.",
+				},
+			]);
+			expect(
+				await runtime.provideContext({ host: "codex", cwd: "/tmp/project", query: "what time is it", signal }),
+			).toEqual([]);
 		} finally {
 			fs.rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Why

PR #26 makes capture reliability measurable and deliberately reports only 25% fully mechanized immediate coverage. Codex already has a per-prompt hook surface, so the next safe increment is to mechanize explicit user requests to remember something without pretending completed-work capture is solved.

## What

- add a Core-owned `coreCaptureContextForQuery()` capture section for explicit memory requests
- return that capture section from `InstalledPluginRuntimeV1.provideContext()` even when no Pro bundle is installed
- rely on the existing Codex `UserPromptSubmit` hook path, whose stdout is injected into the model context
- preserve negative memory instructions such as `Do not remember this`
- add a `partially-mechanized` eval classification so one mechanized path cannot be mistaken for complete harness coverage
- split the evaluation into:
  - `mechanizedExplicitRequestCoverage`: 50% (`claude`, `codex`)
  - `mechanizedImmediateCoverage`: still 25% (`claude` only)

## Why not claim 50% full coverage

This PR does **not** claim deterministic Codex completed-work capture. Current Codex exposes a Stop hook and transcript path, but AgentMemory's existing transcript detector is Claude-shaped. We should only raise full immediate coverage after proving Codex transcript compatibility or adding a dedicated parser and CI fixtures.

## Expected eval baseline

- measured harnesses: 4
- instruction coverage: 100%
- mechanized explicit-request coverage: 50%
- mechanized immediate coverage: 25%
- delegated harnesses: 1 (`pi` via `pi-memory`)

## Stack

Stacked on #26, which is itself stacked on #25. Once those merge, this PR can be retargeted to `main` without changing its semantic diff.